### PR TITLE
base helm chart template

### DIFF
--- a/gravitee/.helmignore
+++ b/gravitee/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/gravitee/Chart.yaml
+++ b/gravitee/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+description: A Helm chart for Kubernetes
+name: gravitee
+version: 0.0.1

--- a/gravitee/NOTES.txt
+++ b/gravitee/NOTES.txt
@@ -1,0 +1,19 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range .Values.ingress.hosts }}
+  http://{{ . }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "gravitee.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get svc -w {{ template "gravitee.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "gravitee.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  echo http://$SERVICE_IP:{{ .Values.service.externalPort }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "gravitee.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl port-forward $POD_NAME 8080:{{ .Values.service.internalPort }}
+{{- end }}

--- a/gravitee/README.md
+++ b/gravitee/README.md
@@ -1,0 +1,69 @@
+# Gravitee Helm Chart
+
+## Chart Details
+
+This chart will deploy the following:
+
+- Gravitee UI
+- Gravitee API
+- Gravitee Gateway
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```bash
+$ helm install --name my-release gravitee
+```
+
+## Configuration
+
+The following tables list the configurable parameters of the Gravitee chart and their default values.
+
+
+### Shared configuration
+
+To configure common functionalities such as:
+- authorisation
+- chaos testing (see
+    [chaoskube](https://github.com/kubernetes/charts/tree/master/stable/chaoskube)
+    chart)
+- configuration database (see
+    [mongodb-replicaset](https://github.com/kubernetes/charts/tree/master/stable/mongodb-replicaset)
+    chart)
+- logs database (see [elastichsearch](https://github.com/kubernetes/charts/tree/master/incubator/elasticsearch)
+    chart)
+
+| Parameter                  | Description              | Default          |
+| -------------------------- | -------------------------| -----------------|
+| `chaos.enabled`            | Enable Chaos test        | false            |
+| `oauth.enabled`            | Enable oauth login       | false            |
+
+### Gravitee UI
+
+| Parameter                  | Description              | Default          |
+| -------------------------- | -------------------------| -----------------|
+| `ui.name`                  | UI service name          | `ui`             |
+
+### Gravitee API
+
+| Parameter             | Description       | Default   |
+|-----------------------|-------------------|-----------|
+| `api.name`            | API service name  | `api`     |
+
+### Gravitee Gateway
+
+| Parameter                    | Description                      | Default        |
+| -----------------------      | ---------------------------------| ---------------|
+| `gateway.name`               | Gateway service name             | `gateway`      |
+
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
+
+Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
+
+```bash
+$ helm install --name my-release -f values.yaml gravitee
+```
+
+> **Tip**: You can use the default [values.yaml](values.yaml)

--- a/gravitee/templates/_helpers.tpl
+++ b/gravitee/templates/_helpers.tpl
@@ -1,0 +1,55 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "gravitee.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "gravitee.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified gateway name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "gravitee.gateway.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- printf "%s-%s" .Release.Name .Values.gateway.name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s-%s" .Release.Name $name .Values.gateway.name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified gateway name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "gravitee.api.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- printf "%s-%s" .Release.Name .Values.api.name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s-%s" .Release.Name $name .Values.api.name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified gateway name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "gravitee.ui.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- printf "%s-%s" .Release.Name .Values.ui.name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s-%s" .Release.Name $name .Values.ui.name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}

--- a/gravitee/templates/api-autoscaler.yaml
+++ b/gravitee/templates/api-autoscaler.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.api.autoscaling.enabled }}
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  labels:
+    app: {{ template "gravitee.name" . }}
+    component: "{{ .Values.api.name }}"
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  name: {{ template "gravitee.api.fullname" . }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1beta1
+    kind: Deployment
+    name: {{ template "gravitee.api.fullname" . }}
+  minReplicas: {{ .Values.api.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.api.autoscaling.maxReplicas }}
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      targetAverageUtilization: {{ .Values.api.autoscaling.targetAverageUtilization }}
+{{- end }}

--- a/gravitee/templates/api-configmap.yaml
+++ b/gravitee/templates/api-configmap.yaml
@@ -1,0 +1,199 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: {{ template "gravitee.name" . }}
+    component: "{{ .Values.api.name }}"
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "gravitee.api.fullname" . }}
+data:
+  gravitee.yml: |
+    management:
+      type: mongodb
+      mongodb:
+        uri: mongodb://{{ .Values.mongo.dbhost }}:{{ .Values.mongo.dbport }}/{{ .Values.mongo.dbname }}{{- if .Values.mongo.rsEnabled }}?replicaSet={{ .Values.mongo.rs }}{{- end }}
+    services:
+      core:
+      http:
+        enabled: true
+        port: 18083
+        host: localhost
+        authentication:
+          type: basic
+          users:
+            admin: adminadmin
+    analytics:
+      type: elasticsearch
+      elasticsearch:
+        endpoints:
+          - {{ .Values.es.protocol }}://{{ .Values.es.host }}:{{ .Values.es.port }}
+        index: {{ .Values.es.index }}
+        cluster: {{ .Values.es.cluster }}
+    security:
+      providers:  # authentication providers
+        - type: gravitee
+        {{- if .Values.oauth.enabled }}
+        - type: oauth2
+          clientId: {{ .Values.oauth.clientId }}
+          clientSecret: {{ .Values.oauth.clientSecret }}
+          tokenEndpoint: {{ .Values.oauth.tokenEndpoint }}
+          userInfoEndpoint: {{ .Values.oauth.userInfoEndpoint }}
+          accessTokenProperty: access_token
+          authorizationHeader: "Bearer %s"
+          mapping:
+            id: sub
+            email: email
+            lastname: family_name
+            firstname: given_name
+            picture: picture
+          #  groups:
+          #    - mapping:
+          #      condition: "{#jsonPath(#profile, '$roles.[?(@.indexOf("USER") > -1)]') == true"
+          #      values: [Example group,soft user]
+        {{- end -}}
+        {{- if .Values.inMemoryAuth.enabled }}
+        - type: memory
+          # password encoding/hashing algorithm. One of:
+          # - bcrypt : passwords are hashed with bcrypt
+          # - none : passwords are not hashed/encrypted
+          # default value is bcrypt
+          password-encoding-algo: bcrypt
+          users:
+            - user:
+              username: user
+              # Passwords are encoded using BCrypt
+              # Password value: password
+              password: $2a$10$9kjw/SH9gucCId3Lnt6EmuFreUAcXSZgpvAYuW2ISv7hSOhHRH1AO
+              roles: MANAGEMENT:USER, PORTAL:USER
+            - user:
+              username: admin
+              # Password value: admin
+              password: $2a$10$Ihk05VSds5rUSgMdsMVi9OKMIx2yUvMz7y9VP3rJmQeizZLrhLMyq
+              roles: ADMIN
+            - user:
+              username: api1
+              # Password value: api1
+              password: $2a$10$iXdXO4wAYdhx2LOwijsp7.PsoAZQ05zEdHxbriIYCbtyo.y32LTji
+              # You can declare multiple roles using comma separator
+              roles: MANAGEMENT:API_PUBLISHER, PORTAL:API_PUBLISHER
+            - user:
+              username: application1
+              # Password value: application1
+              password: $2a$10$2gtKPYRB9zaVaPcn5RBx/.3T.7SeZoDGs9GKqbo9G64fKyXFR1He.
+              roles: MANAGEMENT:USER, PORTAL:USER
+          # Enable authentication using internal repository
+        {{- end }}
+    # SMTP configuration used to send mails
+    email:
+      enabled: true
+      host: smtp.example.com
+      subject: "[gravitee] %s"
+      port: 25
+      from: info@example.com
+      username: info@example.com
+      password: example.com
+      properties:
+        auth: true
+        starttls.enable: false
+
+    # Mail templates
+    templates:
+      path: ${gravitee.home}/templates
+
+    jwt:
+      secret: myJWT4Gr4v1t33_S3cr3t
+      # Allows to define the end of validity of the token in seconds (default 604800 = a week)
+      #expire-after: 604800
+      # Allows to define the end of validity of the token in seconds for email registration (default 86400 = a day)
+      #email-registration-expire-after: 86400
+      # Allows to define issuer (default gravitee-management-auth)
+      #issuer: gravitee-management-auth
+      # Allows to define cookie context path (default /)
+      #cookie-path: /
+      # Allows to define cookie domain (default "")
+      #cookie-domain: .gravitee.io
+      # Allows to define if cookie secure only (default false)
+      #cookie-secure: true
+
+    swagger:
+      # Default scheme used when creating an API from a Swagger descriptor if there is no scheme specified.
+      scheme: https
+
+    user:
+       login:
+          # Create a default application when user connects to the portal for the very first time (default true)
+          #defaultApplication: true
+       creation:
+          # Allows to register new users from portal (default false)
+          #enabled: true
+          token:
+             #expire-after: 86400
+    # The portal URL used in emails
+    portalURL: https://{{ index .Values.ui.ingress.hosts 0 }}
+
+    # Allows to create support ticket (default value: false)
+    support:
+      enabled: true
+
+    # Allows to rate an API (default value: false)
+    #rating :
+      #enabled: true
+  {{- if .Values.api.debugEnabled }}
+  logback.xml: |
+    <?xml version="1.0" encoding="UTF-8"?>
+
+    <!--
+      ~ Copyright (c) 2015-2016, The Gravitee team (http://www.gravitee.io)
+      ~
+      ~  Licensed under the Apache License, Version 2.0 (the "License");
+      ~  you may not use this file except in compliance with the License.
+      ~  You may obtain a copy of the License at
+      ~
+      ~  http://www.apache.org/licenses/LICENSE-2.0
+      ~
+      ~  Unless required by applicable law or agreed to in writing, software
+      ~  distributed under the License is distributed on an "AS IS" BASIS,
+      ~  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      ~  See the License for the specific language governing permissions and
+      ~  limitations under the License.
+      -->
+
+        <configuration>
+
+            <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+                <!-- encoders are assigned the type
+                     ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+                <encoder>
+                    <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+                </encoder>
+            </appender>
+
+            <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+                <file>${gravitee.management.log.dir}/gravitee.log</file>
+                <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+                    <!-- daily rollover -->
+                    <fileNamePattern>${gravitee.management.log.dir}/gravitee_%d{yyyy-MM-dd}.log</fileNamePattern>
+
+                    <!-- keep 30 days' worth of history -->
+                    <maxHistory>30</maxHistory>
+                </rollingPolicy>
+
+                <encoder>
+                    <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+                </encoder>
+            </appender>
+
+            <logger name="io.gravitee" level="DEBUG" />
+            <logger name="org.eclipse.jetty" level="INFO" />
+
+            <!-- Strictly speaking, the level attribute is not necessary since -->
+            <!-- the level of the root level is set to DEBUG by default.       -->
+            <root level="WARN">
+                <appender-ref ref="STDOUT" />
+                <appender-ref ref="FILE" />
+            </root>
+
+        </configuration>
+  {{- end }}

--- a/gravitee/templates/api-deployment.yaml
+++ b/gravitee/templates/api-deployment.yaml
@@ -1,0 +1,64 @@
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: {{ template "gravitee.api.fullname" . }}
+  labels:
+    app: {{ template "gravitee.name" . }}
+    component: "{{ .Values.api.name }}"
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.api.replicaCount }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+  template:
+    metadata:
+      annotations:
+        chaos.alpha.kubernetes.io/enabled: "{{ .Values.chaos.enabled }}"
+      labels:
+        app: {{ template "gravitee.name" . }}
+        component: "{{ .Values.api.name }}"
+        release: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: {{ template "gravitee.api.fullname" . }}
+          image: "{{ .Values.api.image.repository }}:{{ .Values.api.image.tag }}"
+          imagePullPolicy: {{ .Values.api.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.api.service.internalPort }}
+          livenessProbe:
+            httpGet:
+              path: /management/apis
+              port: {{ .Values.api.service.internalPort }}
+            initialDelaySeconds: 60
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /management/apis
+              port: {{ .Values.api.service.internalPort }}
+            initialDelaySeconds: 60
+            periodSeconds: 30
+          resources:
+{{ toYaml .Values.api.resources | indent 12 }}
+    {{- if .Values.api.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.api.nodeSelector | indent 8 }}
+    {{- end }}
+          volumeMounts:
+            - name: config
+              mountPath: /opt/graviteeio-management-api/config/gravitee.yml
+              subPath: gravitee.yml
+          {{- if .Values.api.debugEnabled }}
+            - name: config
+              mountPath: /opt/graviteeio-management-api/config/logback.xml
+              subPath: logback.xml
+          {{- end }}
+      imagePullSecrets:
+        - name: {{ .Values.gateway.image.pullSecrets }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ template "gravitee.api.fullname" . }}

--- a/gravitee/templates/api-ingress.yaml
+++ b/gravitee/templates/api-ingress.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.api.ingress.enabled -}}
+{{- $serviceAPIName := include "gravitee.api.fullname" . -}}
+{{- $serviceAPIPort := .Values.api.service.externalPort -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ template "gravitee.api.fullname" . }}
+  labels:
+    app: {{ template "gravitee.name" . }}
+    component: "{{ .Values.api.name }}"
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  annotations:
+    {{- range $key, $value := .Values.api.ingress.annotations }}
+      {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+  rules:
+    {{- range $host := .Values.api.ingress.hosts }}
+    - host: {{ $host }}
+      http:
+        paths:
+          - path: /
+            backend:
+              serviceName: {{ $serviceAPIName }}
+              servicePort: {{ $serviceAPIPort }}
+    {{- end -}}
+  {{- if .Values.api.ingress.tls }}
+  tls:
+{{ toYaml .Values.api.ingress.tls | indent 4 }}
+  {{- end -}}
+{{- end -}}

--- a/gravitee/templates/api-service.yaml
+++ b/gravitee/templates/api-service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "gravitee.api.fullname" . }}
+  labels:
+    app: {{ template "gravitee.name" . }}
+    component: "{{ .Values.api.name }}"
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.api.service.externalPort }}
+      targetPort: {{ .Values.api.service.internalPort }}
+      protocol: TCP
+      name: {{ .Values.api.name }}
+  selector:
+    app: {{ template "gravitee.name" . }}
+    component: "{{ .Values.api.name }}"
+    release: {{ .Release.Name }}

--- a/gravitee/templates/gateway-autoscaler.yaml
+++ b/gravitee/templates/gateway-autoscaler.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.gateway.autoscaling.enabled }}
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  labels:
+    app: {{ template "gravitee.name" . }}
+    component: "{{ .Values.gateway.name }}"
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  name: {{ template "gravitee.gateway.fullname" . }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1beta1
+    kind: {{ .Values.gateway.type }}
+    name: {{ template "gravitee.gateway.fullname" . }}
+  minReplicas: {{ .Values.gateway.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.gateway.autoscaling.maxReplicas }}
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      targetAverageUtilization: {{ .Values.gateway.autoscaling.targetAverageUtilization }}
+{{- end }}

--- a/gravitee/templates/gateway-configmap.yaml
+++ b/gravitee/templates/gateway-configmap.yaml
@@ -1,0 +1,108 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: {{ template "gravitee.name" . }}
+    component: "{{ .Values.gateway.name }}"
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "gravitee.gateway.fullname" . }}
+data:
+  gravitee.yml: |
+    # Gateway HTTP server
+    http:
+      port: 8082
+      host: 0.0.0.0
+    #  idleTimeout: 0
+    #  tcpKeepAlive: true
+    #  compressionSupported: false
+    #  instances: 0
+    #  secured: false
+      alpn: true
+    #  ssl:
+    #    clientAuth: false
+    #    keystore:
+    #      path: ${gravitee.home}/security/keystore.jks
+    #      password: secret
+    #    truststore:
+    #      path: ${gravitee.home}/security/truststore.jks
+    #      password: secret
+    management:
+      type: mongodb
+      mongodb:
+        uri: mongodb://{{ .Values.mongo.dbhost }}:{{ .Values.mongo.dbport }}/{{ .Values.mongo.dbname }}{{- if .Values.mongo.rsEnabled }}?replicaSet={{ .Values.mongo.rs }}{{- end }}
+    ratelimit:
+      type: mongodb
+      mongodb:
+        uri: mongodb://{{ .Values.mongo.dbhost }}:{{ .Values.mongo.dbport }}/{{ .Values.mongo.dbname }}{{- if .Values.mongo.rsEnabled }}?replicaSet={{ .Values.mongo.rs }}{{- end }}
+    cache:
+      type: ehcache
+      enabled: true
+
+    # Reporters configuration (used to store reporting monitoring data, request metrics, healthchecks and others...
+    # All reporters are enabled by default. To stop one of them, you have to add the property 'enabled: false'
+    reporters:
+      # Reporting system configuration
+      system:
+        buffersize: 4096 # Must be a power of 2
+      # Elasticsearch reporter
+      elasticsearch:
+        enabled: true # Is the reporter enabled or not (default to true)
+        endpoints:
+          - {{ .Values.es.protocol }}://{{ .Values.es.host }}:{{ .Values.es.port }}
+        index: {{ .Values.es.index }}
+        cluster: {{ .Values.es.cluster }}
+        bulk:
+          actions: 200           # Number of requests action before flush
+          flush_interval: 5       # Flush interval in seconds
+          concurrent_requests: 5  # Concurrent requests
+    services:
+      core:
+        http:
+          port: 18082
+          host: localhost
+          authentication:
+            # authentication type to be used for the core services
+            # - none : to disable authentication
+            # - basic : to use basic authentication
+            # default is "basic"
+            type: basic
+            users:
+              admin: adminadmin
+      # Synchronization daemon used to keep the gateway state in sync with the configuration from the management repository
+      # Be aware that, by disabling it, the gateway will not be sync with the configuration done through management API
+      # and management UI
+      sync:
+        # Synchronization is done each 5 seconds
+        cron: '*/5 * * * * *'
+
+      # Service used to store and cache api-keys from the management repository to avoid direct repository communication
+      # while serving requests.
+      apikeyscache:
+        delay: 10000
+        unit: MILLISECONDS
+        threads: 3 # Threads core size used to retrieve api-keys from repository.
+
+      # Local registry service.
+      # This registry is used to load API Definition with json format from the file system. By doing so, you do not need
+      # to configure your API using the web console or the rest API (but you need to know and understand the json descriptor
+      # format to make it work....)
+      local:
+        enabled: false
+        path: ${gravitee.home}/apis # The path to API descriptors
+
+      # Gateway monitoring service.
+      # This service retrieves metrics like os / process / jvm metrics and send them to an underlying reporting service.
+      monitoring:
+        delay: 5000
+        unit: MILLISECONDS
+
+      # Endpoint healthcheck service.
+      healthcheck:
+        threads: 3 # Threads core size used to check endpoint availability
+
+    handlers:
+      request:
+        transaction:
+          header: X-Gravitee-Transaction-Id

--- a/gravitee/templates/gateway-deployment.yaml
+++ b/gravitee/templates/gateway-deployment.yaml
@@ -1,0 +1,64 @@
+apiVersion: apps/v1beta1
+kind: {{ .Values.gateway.type }}
+metadata:
+  name: {{ template "gravitee.gateway.fullname" . }}
+  labels:
+    app: {{ template "gravitee.name" . }}
+    component: "{{ .Values.gateway.name }}"
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  {{- if eq .Values.gateway.type "StatefulSet" }}
+  serviceName: {{ template "gravitee.gateway.fullname" . }}
+  updateStrategy:
+    type: RollingUpdate
+  {{- end }}
+  {{- if eq .Values.gateway.type "Deployment" }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+  {{- end }}
+  replicas: {{ .Values.gateway.replicaCount }}
+  template:
+    metadata:
+      annotations:
+        chaos.alpha.kubernetes.io/enabled: "{{ .Values.chaos.enabled }}"
+      labels:
+        app: {{ template "gravitee.name" . }}
+        component: "{{ .Values.gateway.name }}"
+        release: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: {{ template "gravitee.gateway.fullname" . }}
+          image: "{{ .Values.gateway.image.repository }}:{{ .Values.gateway.image.tag }}"
+          imagePullPolicy: {{ .Values.gateway.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.gateway.service.internalPort }}
+          livenessProbe:
+            tcpSocket:
+              port: {{ .Values.gateway.service.internalPort }}
+            initialDelaySeconds: 60
+            periodSeconds: 30
+          readinessProbe:
+            tcpSocket:
+              port: {{ .Values.gateway.service.internalPort }}
+            initialDelaySeconds: 5
+            periodSeconds: 30
+          resources:
+{{ toYaml .Values.gateway.resources | indent 12 }}
+    {{- if .Values.gateway.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.gateway.nodeSelector | indent 8 }}
+    {{- end }}
+          volumeMounts:
+            - name: config
+              mountPath: /opt/graviteeio-gateway/config/gravitee.yml
+              subPath: gravitee.yml
+      imagePullSecrets:
+        - name: {{ .Values.gateway.image.pullSecrets }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ template "gravitee.gateway.fullname" . }}

--- a/gravitee/templates/gateway-ingress.yaml
+++ b/gravitee/templates/gateway-ingress.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.gateway.ingress.enabled -}}
+{{- $serviceGWName := include "gravitee.gateway.fullname" . -}}
+{{- $serviceGWPort := .Values.gateway.service.externalPort -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ template "gravitee.gateway.fullname" . }}
+  labels:
+    app: {{ template "gravitee.name" . }}
+    component: "{{ .Values.gateway.name }}"
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  annotations:
+    {{- range $key, $value := .Values.gateway.ingress.annotations }}
+      {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+  rules:
+    {{- range $host := .Values.gateway.ingress.hosts }}
+    - host: {{ $host }}
+      http:
+        paths:
+          - path: /
+            backend:
+              serviceName: {{ $serviceGWName }}
+              servicePort: {{ $serviceGWPort }}
+    {{- end -}}
+  {{- if .Values.gateway.ingress.tls }}
+  tls:
+{{ toYaml .Values.gateway.ingress.tls | indent 4 }}
+  {{- end -}}
+{{- end -}}

--- a/gravitee/templates/gateway-service.yaml
+++ b/gravitee/templates/gateway-service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "gravitee.gateway.fullname" . }}
+  labels:
+    app: {{ template "gravitee.name" . }}
+    component: "{{ .Values.gateway.name }}"
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.gateway.service.externalPort }}
+      targetPort: {{ .Values.gateway.service.internalPort }}
+      protocol: TCP
+      name: {{ .Values.gateway.name }}
+  selector:
+    app: {{ template "gravitee.name" . }}
+    component: "{{ .Values.gateway.name }}"
+    release: {{ .Release.Name }}

--- a/gravitee/templates/ui-autoscaler.yaml
+++ b/gravitee/templates/ui-autoscaler.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.ui.autoscaling.enabled }}
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  labels:
+    app: {{ template "gravitee.name" . }}
+    component: "{{ .Values.ui.name }}"
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  name: {{ template "gravitee.ui.fullname" . }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1beta1
+    kind: Deployment
+    name: {{ template "gravitee.ui.fullname" . }}
+  minReplicas: {{ .Values.ui.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.ui.autoscaling.maxReplicas }}
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      targetAverageUtilization: {{ .Values.ui.autoscaling.targetAverageUtilization }}
+{{- end }}

--- a/gravitee/templates/ui-configmap.yaml
+++ b/gravitee/templates/ui-configmap.yaml
@@ -1,0 +1,61 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: {{ template "gravitee.name" . }}
+    component: "{{ .Values.ui.name }}"
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "gravitee.ui.fullname" . }}
+data:
+  constants.json: |
+    {
+      "baseURL": "https://{{ index .Values.api.ingress.hosts 0 }}/management/",
+      "portalTitle": "Gravitee API Portal",
+      "managementTitle": "API Management",
+      "devMode": false,
+      "userCreationEnabled": false,
+      "documentation": {
+        "url": "https://docs.gravitee.io"
+      },
+      {{- if .Values.oauth.enabled }}
+      "authentication": {
+        {{- if .Values.oauth.localLoginDisabled }}
+        "localLoginDisabled": {{ .Values.oauth.localLoginDisabled }},
+        {{- end }}
+        "oauth2": {
+          "clientId": "{{ .Values.oauth.clientId }}",
+          "name": "Gravitee",
+          "color": "#0076b4",
+          "authorizationEndpoint": "{{ .Values.oauth.authorizationEndpoint }}",
+          {{- if .Values.oauth.localLoginDisabled }}
+          "userLogoutEndpoint": "{{ .Values.oauth.userLogoutEndpoint }}",
+          {{- end }}
+          "scope": [{{- range $i, $scope := .Values.oauth.scope }}{{- if $i}}, {{- end -}} "{{ $scope }}" {{- end -}}]
+        }
+      },
+      {{- end }}
+      "portal": {
+        "entrypoint": "{{ index .Values.gateway.ingress.hosts 0 }}",
+        "apikeyHeader": "X-Gravitee-Api-Key"
+      },
+      "theme": {
+        "name": "default",
+        "logo": "themes/assets/logo.png",
+        "loader": "assets/gravitee_logo_anim.gif"
+      },
+      "support": {
+        "enabled": true
+      },
+      "rating": {
+        "enabled": false
+      },
+      "analytics": {
+        "enabled": false,
+        "trackingId": ""
+      },
+      "scheduler": {
+        "tasks": 10
+      }
+    }

--- a/gravitee/templates/ui-deployment.yaml
+++ b/gravitee/templates/ui-deployment.yaml
@@ -1,0 +1,62 @@
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: {{ template "gravitee.ui.fullname" . }}
+  labels:
+    app: {{ template "gravitee.name" . }}
+    component: "{{ .Values.ui.name }}"
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.ui.replicaCount }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+  template:
+    metadata:
+      annotations:
+        chaos.alpha.kubernetes.io/enabled: "{{ .Values.chaos.enabled }}"
+      labels:
+        app: {{ template "gravitee.name" . }}
+        component: "{{ .Values.ui.name }}"
+        release: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: {{ template "gravitee.ui.fullname" . }}
+          image: "{{ .Values.ui.image.repository }}:{{ .Values.ui.image.tag }}"
+          imagePullPolicy: {{ .Values.ui.image.pullPolicy }}
+          env:
+            - name: MGMT_API_URL
+              value: "https://{{index .Values.api.ingress.hosts 0 }}/management/"
+          ports:
+            - containerPort: {{ .Values.ui.service.internalPort }}
+          livenessProbe:
+            httpGet:
+              path: /
+              port: {{ .Values.ui.service.internalPort }}
+            initialDelaySeconds: 30
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /
+              port: {{ .Values.ui.service.internalPort }}
+            initialDelaySeconds: 30
+            periodSeconds: 30
+          resources:
+{{ toYaml .Values.ui.resources | indent 12 }}
+    {{- if .Values.ui.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.ui.nodeSelector | indent 8 }}
+    {{- end }}
+          volumeMounts:
+            - name: config
+              mountPath: /var/www/html/constants.json
+              subPath: constants.json
+      imagePullSecrets:
+        - name: {{ .Values.ui.image.pullSecrets }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ template "gravitee.ui.fullname" . }}

--- a/gravitee/templates/ui-ingress.yaml
+++ b/gravitee/templates/ui-ingress.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.ui.ingress.enabled -}}
+{{- $serviceAPIName := include "gravitee.ui.fullname" . -}}
+{{- $serviceAPIPort := .Values.ui.service.externalPort -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ template "gravitee.ui.fullname" . }}
+  labels:
+    app: {{ template "gravitee.name" . }}
+    component: "{{ .Values.ui.name }}"
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  annotations:
+    {{- range $key, $value := .Values.ui.ingress.annotations }}
+      {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+  rules:
+    {{- range $host := .Values.ui.ingress.hosts }}
+    - host: {{ $host }}
+      http:
+        paths:
+          - path: /
+            backend:
+              serviceName: {{ $serviceAPIName }}
+              servicePort: {{ $serviceAPIPort }}
+    {{- end -}}
+  {{- if .Values.ui.ingress.tls }}
+  tls:
+{{ toYaml .Values.ui.ingress.tls | indent 4 }}
+  {{- end -}}
+{{- end -}}

--- a/gravitee/templates/ui-service.yaml
+++ b/gravitee/templates/ui-service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "gravitee.ui.fullname" . }}
+  labels:
+    app: {{ template "gravitee.name" . }}
+    component: "{{ .Values.ui.name }}"
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.ui.service.externalPort }}
+      targetPort: {{ .Values.ui.service.internalPort }}
+      protocol: TCP
+      name: {{ .Values.ui.name }}
+  selector:
+    app: {{ template "gravitee.name" . }}
+    component: "{{ .Values.ui.name }}"
+    release: {{ .Release.Name }}

--- a/gravitee/values.yaml
+++ b/gravitee/values.yaml
@@ -1,0 +1,175 @@
+# Default values for gravitee.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+chaos:
+  enabled: false
+
+oauth:
+  enabled: false
+  localLoginDisabled: true
+  # OAuth2 token validation endpoint url
+  tokenEndpoint: https://auth/realms/default/protocol/openid-connect/token
+  # Authorization endpoint to ask for an authorization_code
+  authorizationEndpoint: https://auth/realms/default/protocol/openid-connect/auth
+  userInfoEndpoint: https://auth/realms/default/protocol/openid-connect/userinfo
+  userLogoutEndpoint: https://uth/realms/default/protocol/openid-connect/logout
+  # OAuth2 resource server client id
+  clientId: client
+  # OAut2 resource server client secret
+  clientSecret: secret
+  # Required scope
+  scope:
+    - profile
+    - openid
+
+inMemoryAuth:
+  enabled: true
+
+mongo:
+  rs: rs
+  rsEnabled: true
+  dbhost: mongo-rs-mongodb-replicaset
+  dbname: gravitee
+  dbport: 27017
+
+es:
+  protocol: http
+  cluster: elasticsearch
+  index: gravitee
+  host: elasticsearch-elasticsearch-client
+  port: 9200
+
+api:
+  name: api
+  debugEnabled: false
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 1
+    type: RollingUpdate
+  replicaCount: 1
+  image:
+    repository: graviteeio/management-api
+    tag: 1.15.0
+    pullPolicy: Always
+  service:
+    type: ClusterIP
+    externalPort: 83
+    internalPort: 8083
+  autoscaling:
+    enabled: true
+    minReplicas: 2
+    maxReplicas: 3
+    targetAverageUtilization: 50
+  ingress:
+    enabled: true
+    # Used to create an Ingress record.
+    hosts:
+      - api-manager.example.com
+    annotations:
+      kubernetes.io/ingress.class: nginx
+      ingress.kubernetes.io/configuration-snippet: "gzip off;\netag on;\nproxy_pass_header ETag;\nproxy_set_header if-match \"\";\n"
+      # kubernetes.io/tls-acme: "true"
+    tls:
+      # Secrets must be manually created in the namespace.
+      # - secretName: chart-example-tls
+      #   hosts:
+      #     - chart-example.local
+  resources:
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    limits:
+      cpu: 500m
+      memory: 1024Mi
+    requests:
+      cpu: 200m
+      memory: 512Mi
+
+
+gateway:
+  type: Deployment
+  name: gateway
+  replicaCount: 2
+  image:
+    repository: graviteeio/gateway
+    tag: 1.15.0
+    pullPolicy: Always
+  service:
+    type: ClusterIP
+    externalPort: 82
+    internalPort: 8082
+  autoscaling:
+    enabled: true
+    minReplicas: 2
+    maxReplicas: 6
+    targetAverageUtilization: 50
+  ingress:
+    enabled: true
+    # Used to create an Ingress record.
+    hosts:
+      - api.example.com
+    annotations:
+      kubernetes.io/ingress.class: nginx
+      ingress.kubernetes.io/configuration-snippet: "gzip off;\netag on;\nproxy_pass_header ETag;\n"
+      # kubernetes.io/tls-acme: "true"
+    tls:
+      # Secrets must be manually created in the namespace.
+      # - secretName: chart-example-tls
+      #   hosts:
+      #     - chart-example.local
+  resources:
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    limits:
+      cpu: 500m
+      memory: 512Mi
+    requests:
+      cpu: 200m
+      memory: 256Mi
+
+ui:
+  name: ui
+  replicaCount: 1
+  image:
+    repository: graviteeio/management-ui
+    tag: 1.15.0
+    pullPolicy: Always
+  autoscaling:
+    enabled: true
+    minReplicas: 2
+    maxReplicas: 3
+    targetAverageUtilization: 50
+  service:
+    name: nginx
+    type: ClusterIP
+    externalPort: 8002
+    internalPort: 80
+  ingress:
+    enabled: true
+    # Used to create an Ingress record.
+    hosts:
+      - developer.example.com
+    annotations:
+      kubernetes.io/ingress.class: nginx
+      kubernetes.io/app-root: /management
+      kubernetes.io/rewrite-target: /management
+      ingress.kubernetes.io/configuration-snippet: "gzip off;\netag on;\nproxy_pass_header ETag;\n"
+    tls:
+      # Secrets must be manually created in the namespace.
+      # - secretName: chart-example-tls
+      #   hosts:
+      #     - chart-example.local
+  resources:
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    limits:
+      cpu: 100m
+      memory: 128Mi
+    requests:
+      cpu: 50m
+      memory: 64Mi


### PR DESCRIPTION
few comments:
* readme must be completed
* few things (e.g. smpt configuration are not configurable in the value.yml)
* tested with gravitee 1.15.0, mongodb 3.2 (version of the helm chart  2.1.4) elk 5.6 (version of the helm chart 0.4.9) 
* some part of the configuration assume usage of ingress services (we tested only with nginx, but of course it should work with other services, configuration may be different from the one in value.yml)