### PR TITLE
Fix incorrect indent in configmap

### DIFF
--- a/gravitee/templates/api-configmap.yaml
+++ b/gravitee/templates/api-configmap.yaml
@@ -120,60 +120,60 @@ data:
     # Allows to rate an API (default value: false)
     #rating :
       #enabled: true
-    {{- if .Values.api.debugEnabled }}
-    logback.xml: |
-      <?xml version="1.0" encoding="UTF-8"?>
+  {{- if .Values.api.debugEnabled }}
+  logback.xml: |
+    <?xml version="1.0" encoding="UTF-8"?>
 
-      <!--
-        ~ Copyright (c) 2015-2016, The Gravitee team (http://www.gravitee.io)
-        ~
-        ~  Licensed under the Apache License, Version 2.0 (the "License");
-        ~  you may not use this file except in compliance with the License.
-        ~  You may obtain a copy of the License at
-        ~
-        ~  http://www.apache.org/licenses/LICENSE-2.0
-        ~
-        ~  Unless required by applicable law or agreed to in writing, software
-        ~  distributed under the License is distributed on an "AS IS" BASIS,
-        ~  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-        ~  See the License for the specific language governing permissions and
-        ~  limitations under the License.
-        -->
+    <!--
+      ~ Copyright (c) 2015-2016, The Gravitee team (http://www.gravitee.io)
+      ~
+      ~  Licensed under the Apache License, Version 2.0 (the "License");
+      ~  you may not use this file except in compliance with the License.
+      ~  You may obtain a copy of the License at
+      ~
+      ~  http://www.apache.org/licenses/LICENSE-2.0
+      ~
+      ~  Unless required by applicable law or agreed to in writing, software
+      ~  distributed under the License is distributed on an "AS IS" BASIS,
+      ~  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      ~  See the License for the specific language governing permissions and
+      ~  limitations under the License.
+      -->
 
-          <configuration>
+        <configuration>
 
-              <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-                  <!-- encoders are assigned the type
-                      ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
-                  <encoder>
-                      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
-                  </encoder>
-              </appender>
+            <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+                <!-- encoders are assigned the type
+                    ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+                <encoder>
+                    <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+                </encoder>
+            </appender>
 
-              <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-                  <file>${gravitee.management.log.dir}/gravitee.log</file>
-                  <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-                      <!-- daily rollover -->
-                      <fileNamePattern>${gravitee.management.log.dir}/gravitee_%d{yyyy-MM-dd}.log</fileNamePattern>
+            <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+                <file>${gravitee.management.log.dir}/gravitee.log</file>
+                <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+                    <!-- daily rollover -->
+                    <fileNamePattern>${gravitee.management.log.dir}/gravitee_%d{yyyy-MM-dd}.log</fileNamePattern>
 
-                      <!-- keep 30 days' worth of history -->
-                      <maxHistory>30</maxHistory>
-                  </rollingPolicy>
+                    <!-- keep 30 days' worth of history -->
+                    <maxHistory>30</maxHistory>
+                </rollingPolicy>
 
-                  <encoder>
-                      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
-                  </encoder>
-              </appender>
+                <encoder>
+                    <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+                </encoder>
+            </appender>
 
-              <logger name="io.gravitee" level="DEBUG" />
-              <logger name="org.eclipse.jetty" level="INFO" />
+            <logger name="io.gravitee" level="DEBUG" />
+            <logger name="org.eclipse.jetty" level="INFO" />
 
-              <!-- Strictly speaking, the level attribute is not necessary since -->
-              <!-- the level of the root level is set to DEBUG by default.       -->
-              <root level="WARN">
-                  <appender-ref ref="STDOUT" />
-                  <appender-ref ref="FILE" />
-              </root>
+            <!-- Strictly speaking, the level attribute is not necessary since -->
+            <!-- the level of the root level is set to DEBUG by default.       -->
+            <root level="WARN">
+                <appender-ref ref="STDOUT" />
+                <appender-ref ref="FILE" />
+            </root>
 
-          </configuration>
-    {{- end }}
+        </configuration>
+  {{- end }}


### PR DESCRIPTION
When configuring debug for the API the logback.xml is incorrectly configured and causes an error starting the application.