### PR TITLE
Gateway debug logging flag

### DIFF
--- a/gravitee/README.md
+++ b/gravitee/README.md
@@ -121,7 +121,7 @@ To configure common functionalities such as:
 | Parameter             | Description       | Default   |
 |-----------------------|-------------------|-----------|
 | `api.name`            | API service name  | `api`     |
-| `api.debugEnabled`    | Whether to enable API debug or not  | `false`     |
+| `api.logging.debug`    | Whether to enable API debug logging or not  | `false`     |
 | `api.restartPolicy`            | Policy to [restart K8 pod](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-and-container-status)  | `OnFailure`     |
 | `api.updateStrategy.type`            | [K8s deployment strategy type](https://kubernetes.io/zh/docs/concepts/workloads/controllers/deployment/)  | `RollingUpdate`     |
 | `api.updateStrategy.rollingUpdate.maxUnavailable`            | If api.updateStrategy.type is set to `RollingUpdate`, make sure to set a value here or your Deployment can have 100% unavailability by default.  The Deployment controller will stop the bad rollout automatically, and will stop scaling up the new ReplicaSet. This depends on the rollingUpdate parameters (maxUnavailable specifically) that you have specified. Kubernetes by default sets the value to 1 and spec.replicas to 1 so if you haven’t cared about setting those parameters, your Deployment can have 100% unavailability by default!   | `1`     |
@@ -151,6 +151,7 @@ To configure common functionalities such as:
 | Parameter                    | Description                      | Default        |
 | -----------------------      | ---------------------------------| ---------------|
 | `gateway.name`               | Gateway service name             | `gateway`      |
+| `gateway.logging.debug`    | Whether to enable Gateway debug logging or not  | `false`     |
 | `gateway.type`               | Gateway deployment type: `deployment` or `statefulSet`            | `deployment` |
 | `gateway.replicaCount`       | How many replicas of the Gateway pod | `2`
 | `gateway.image.repository`   | Gravitee Gateway image repository | `graviteeio/gateway`

--- a/gravitee/templates/api-configmap.yaml
+++ b/gravitee/templates/api-configmap.yaml
@@ -120,7 +120,7 @@ data:
     # Allows to rate an API (default value: false)
     #rating :
       #enabled: true
-  {{- if .Values.api.debugEnabled }}
+  {{- if .Values.api.logging.debug }}
   logback.xml: |
     <?xml version="1.0" encoding="UTF-8"?>
 

--- a/gravitee/templates/api-deployment.yaml
+++ b/gravitee/templates/api-deployment.yaml
@@ -49,7 +49,7 @@ spec:
             - name: config
               mountPath: /opt/graviteeio-management-api/config/gravitee.yml
               subPath: gravitee.yml
-          {{- if .Values.api.debugEnabled }}
+          {{- if .Values.api.logging.debug }}
             - name: config
               mountPath: /opt/graviteeio-management-api/config/logback.xml
               subPath: logback.xml

--- a/gravitee/templates/gateway-configmap.yaml
+++ b/gravitee/templates/gateway-configmap.yaml
@@ -106,3 +106,70 @@ data:
       request:
         transaction:
           header: X-Gravitee-Transaction-Id
+  {{- if .Values.gateway.debugEnabled }}
+  logback.xml: |
+    <?xml version="1.0" encoding="UTF-8"?>
+
+    <!--
+      ~ Copyright (c) 2015-2016, The Gravitee team (http://www.gravitee.io)
+      ~
+      ~  Licensed under the Apache License, Version 2.0 (the "License");
+      ~  you may not use this file except in compliance with the License.
+      ~  You may obtain a copy of the License at
+      ~
+      ~  http://www.apache.org/licenses/LICENSE-2.0
+      ~
+      ~  Unless required by applicable law or agreed to in writing, software
+      ~  distributed under the License is distributed on an "AS IS" BASIS,
+      ~  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      ~  See the License for the specific language governing permissions and
+      ~  limitations under the License.
+      -->
+
+    <configuration>
+
+        <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+            <!-- encoders are assigned the type
+                ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+            <encoder>
+                <pattern>%d{HH:mm:ss.SSS} [%thread] [%X{api}] %-5level %logger{36} - %msg%n</pattern>
+            </encoder>
+        </appender>
+
+        <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+            <file>${gravitee.home}/logs/gravitee.log</file>
+            <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+                <!-- daily rollover -->
+                <fileNamePattern>${gravitee.home}/logs/gravitee_%d{yyyy-MM-dd}.log</fileNamePattern>
+
+                <!-- keep 30 days' worth of history -->
+                <maxHistory>30</maxHistory>
+            </rollingPolicy>
+
+            <encoder>
+                <pattern>%d{HH:mm:ss.SSS} [%thread] [%X{api}] %-5level %logger{36} - %msg%n</pattern>
+            </encoder>
+        </appender>
+
+        <appender name="async-file" class="ch.qos.logback.classic.AsyncAppender">
+            <appender-ref ref="FILE" />
+        </appender>
+
+        <appender name="async-console" class="ch.qos.logback.classic.AsyncAppender">
+            <appender-ref ref="STDOUT" />
+        </appender>
+
+        <logger name="io.gravitee" level="DEBUG" />
+        <logger name="org.reflections" level="WARN" />
+        <logger name="org.springframework" level="WARN" />
+        <logger name="org.eclipse.jetty" level="WARN" />
+
+        <!-- Strictly speaking, the level attribute is not necessary since -->
+        <!-- the level of the root level is set to DEBUG by default.       -->
+        <root level="INFO">
+            <appender-ref ref="async-console" />
+            <appender-ref ref="async-file" />
+        </root>
+
+    </configuration>
+  {{- end }}

--- a/gravitee/templates/gateway-configmap.yaml
+++ b/gravitee/templates/gateway-configmap.yaml
@@ -173,3 +173,4 @@ data:
 
     </configuration>
   {{- end }}
+  

--- a/gravitee/templates/gateway-configmap.yaml
+++ b/gravitee/templates/gateway-configmap.yaml
@@ -106,7 +106,7 @@ data:
       request:
         transaction:
           header: X-Gravitee-Transaction-Id
-  {{- if .Values.gateway.debugEnabled }}
+  {{- if .Values.gateway.logging.debug }}
   logback.xml: |
     <?xml version="1.0" encoding="UTF-8"?>
 
@@ -173,4 +173,3 @@ data:
 
     </configuration>
   {{- end }}
-  

--- a/gravitee/templates/gateway-deployment.yaml
+++ b/gravitee/templates/gateway-deployment.yaml
@@ -56,6 +56,11 @@ spec:
             - name: config
               mountPath: /opt/graviteeio-gateway/config/gravitee.yml
               subPath: gravitee.yml
+          {{- if .Values.gateway.debugEnabled }}
+            - name: config
+              mountPath: /opt/graviteeio-gateway/config/logback.xml
+              subPath: logback.xml
+          {{- end }}
       imagePullSecrets:
         - name: {{ .Values.gateway.image.pullSecrets }}
       volumes:

--- a/gravitee/templates/gateway-deployment.yaml
+++ b/gravitee/templates/gateway-deployment.yaml
@@ -56,7 +56,7 @@ spec:
             - name: config
               mountPath: /opt/graviteeio-gateway/config/gravitee.yml
               subPath: gravitee.yml
-          {{- if .Values.gateway.debugEnabled }}
+          {{- if .Values.gateway.logging.debug }}
             - name: config
               mountPath: /opt/graviteeio-gateway/config/logback.xml
               subPath: logback.xml

--- a/gravitee/values.yaml
+++ b/gravitee/values.yaml
@@ -39,7 +39,8 @@ es:
 
 api:
   name: api
-  debugEnabled: false
+  logging:
+    debug: false
   restartPolicy: OnFailure
   updateStrategy:
     rollingUpdate:
@@ -92,7 +93,8 @@ api:
 gateway:
   type: Deployment
   name: gateway
-  debugEnabled: false
+  logging:
+    debug: false
   replicaCount: 2
   image:
     repository: graviteeio/gateway

--- a/gravitee/values.yaml
+++ b/gravitee/values.yaml
@@ -92,6 +92,7 @@ api:
 gateway:
   type: Deployment
   name: gateway
+  debugEnabled: false
   replicaCount: 2
   image:
     repository: graviteeio/gateway


### PR DESCRIPTION
I just had the need to enable debug logging for the gateway to solve a problem.

Unfortunately this was not possible with the chart but it is possible for the api deployment.

I added the necessary code to enable the debug logs for the gateway with the `gateway.debugEnabled`  flag.