### PR TITLE
Fix broken ingress path variable

### DIFF
--- a/gravitee/templates/api-ingress.yaml
+++ b/gravitee/templates/api-ingress.yaml
@@ -1,6 +1,7 @@
 {{- if .Values.api.ingress.enabled -}}
 {{- $serviceAPIName := include "gravitee.api.fullname" . -}}
 {{- $serviceAPIPort := .Values.api.service.externalPort -}}
+{{- $ingressPath   := .Values.api.ingress.path -}}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
@@ -21,7 +22,7 @@ spec:
     - host: {{ $host }}
       http:
         paths:
-          - path: {{ .Values.api.ingress.path }}
+          - path: {{ $ingressPath }}
             backend:
               serviceName: {{ $serviceAPIName }}
               servicePort: {{ $serviceAPIPort }}

--- a/gravitee/templates/gateway-ingress.yaml
+++ b/gravitee/templates/gateway-ingress.yaml
@@ -1,6 +1,7 @@
 {{- if .Values.gateway.ingress.enabled -}}
 {{- $serviceGWName := include "gravitee.gateway.fullname" . -}}
 {{- $serviceGWPort := .Values.gateway.service.externalPort -}}
+{{- $ingressPath   := .Values.gateway.ingress.path -}}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
@@ -21,7 +22,7 @@ spec:
     - host: {{ $host }}
       http:
         paths:
-          - path: {{ .Values.gateway.ingress.path }}
+          - path: {{ $ingressPath }}
             backend:
               serviceName: {{ $serviceGWName }}
               servicePort: {{ $serviceGWPort }}


### PR DESCRIPTION
With https://github.com/gravitee-io/gravitee-kubernetes/pull/9 the helm chart got messed up, because inside the `range $host` part we cannot reference the variable `ingress.path` directly.

@brasseld  sorry for the messup.
I fixed it and got it deployed this way. 