### PR TITLE
fix missing replayed_release param for non dry run on standalone replay nexus

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -331,6 +331,7 @@ workflows:
           # maven_profile_id: << pipeline.parameters.maven_profile_id >>
           maven_profile_id: "gravitee-release"
           s3_bucket_name: << pipeline.parameters.s3_bucket_name >>
+          gio_release_version: << pipeline.parameters.replayed_release >>
           # container_gun_image_org: 'circleci'
           # container_gun_image_name: 'openjdk'
           # container_gun_image_tag: '11.0.3-jdk-stretch'


### PR DESCRIPTION
fix missing replayed_release param for non dry run on standalone replay nexus


tested successful : https://app.circleci.com/pipelines/github/gravitee-io/gravitee-kubernetes/170/workflows/e9d51532-fc39-4b39-8baf-b45853c31172/jobs/389