### PR TITLE
Cicd/package bundle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 parameters:
   gio_action:
     type: enum
-    enum: [release, standalone_release, standalone_release_replay, nexus_staging, vm_nexus_staging, pull_requests]
+    enum: [release, standalone_release, standalone_release_replay, nexus_staging, standalone_package_bundle, vm_nexus_staging, pull_requests]
     default: pull_requests
   dry_run:
     type: boolean
@@ -24,11 +24,16 @@ parameters:
   s3_bucket_name:
     type: string
     default: ''
-    description: "Name of the S3 Bucket used to store and retrieve the state of the maven project, to perform the nexus staging ?"
+    description: "When used with the Nexus Staging related process, or Release process, Name of the S3 Bucket used to store and retrieve the state of the maven project, to perform the nexus staging. When used for the package bundle, the Name of the S3 Bucket to publish to https://download.gravitee.io ?"
   replayed_release:
     type: string
     default: $GIO_RELEASE_VERSION
     description: "What is the version number of the release you want to replay? (Mandatory, only for the 'standalone_release_replay' Workflow / see 'gio_action' pipeline parameter)"
+  package_bundle_version:
+    type: string
+    default: ''
+    description: "The release version in the https://github.com/gravitee-io/gravitee-kubernetes git repo, for which to perform the package bundle"
+
 orbs:
   slack: circleci/slack@4.2.1
   gravitee: gravitee-io/gravitee@dev:1.0.4
@@ -337,6 +342,21 @@ workflows:
           # container_gun_image_tag: '11.0.3-jdk-stretch'
           container_size: 'large'
 
+
+  standalone_package_bundle:
+    when:
+      equal: [ standalone_package_bundle, << pipeline.parameters.gio_action >> ]
+    jobs:
+      - gravitee/d_release_secrets:
+          context: cicd-orchestrator
+          name: release_secrets_resolution
+      - gravitee/d_gio_kube_package_bundle:
+          name: package_bundle
+          requires:
+            - release_secrets_resolution
+          # maven_profile_id: "gio-release"
+          dry_run: << pipeline.parameters.dry_run >>
+          gio_release_version: << pipeline.parameters.package_bundle_version >>
 
   # ---
   # CICD Workflow For APIM Orchestrated Nexus Staging, VM-based


### PR DESCRIPTION
This new Circle CI Pipeline provides a Package Bundle For Gravitee Kubernetes : 
* https://download.gravitee.io/#graviteeio-apim/plugins/services/gravitee-kubernetes-controller/ is now available
* to test the package bundle new process, run : 

```bash
export CCI_TOKEN=<you circle ci token>
export ORG_NAME="gravitee-io"
export REPO_NAME="gravitee-kubernetes"
# on master branch when the PR is merged into master git branch
export BRANCH="master"
export BRANCH="cicd/package-bundle"
export GIO_RELEASE_VERSION="0.1.0"
export JSON_PAYLOAD="{

    \"branch\": \"${BRANCH}\",
    \"parameters\":

    {
        \"gio_action\": \"standalone_package_bundle\",
        \"package_bundle_version\": \"${GIO_RELEASE_VERSION}\",
        \"dry_run\": false
    }

}"

curl -X GET -H 'Content-Type: application/json' -H 'Accept: application/json' -H "Circle-Token: ${CCI_TOKEN}" https://circleci.com/api/v2/me | jq .
curl -X POST -d "${JSON_PAYLOAD}" -H 'Content-Type: application/json' -H 'Accept: application/json' -H "Circle-Token: ${CCI_TOKEN}" https://circleci.com/api/v2/project/gh/${ORG_NAME}/${REPO_NAME}/pipeline | jq .

```

And the doc : https://github.com/gravitee-io/kb/wiki/CICD:-The-Gravitee-Kubernetes-(Controller)