### PR TITLE
fix: use a dedicated instance of vertx in kubernetes client

### DIFF
--- a/gravitee-kubernetes-client/src/main/java/io/gravitee/kubernetes/client/impl/KubernetesClientV1Impl.java
+++ b/gravitee-kubernetes-client/src/main/java/io/gravitee/kubernetes/client/impl/KubernetesClientV1Impl.java
@@ -25,6 +25,7 @@ import io.gravitee.kubernetes.client.model.v1.Watchable;
 import io.reactivex.rxjava3.core.BackpressureStrategy;
 import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.core.Maybe;
+import io.vertx.core.VertxOptions;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.http.HttpHeaders;
@@ -56,8 +57,10 @@ public class KubernetesClientV1Impl implements KubernetesClient {
 
     private static final char WATCH_KEY_SEPARATOR = '#';
 
-    public KubernetesClientV1Impl(Vertx vertx) {
-        this.vertx = vertx;
+    public KubernetesClientV1Impl() {
+        VertxOptions options = new VertxOptions();
+        options.getMetricsOptions().setEnabled(false);
+        this.vertx = Vertx.vertx(options);
     }
 
     @Override

--- a/gravitee-kubernetes-client/src/main/java/io/gravitee/kubernetes/client/spring/KubernetesClientConfiguration.java
+++ b/gravitee-kubernetes-client/src/main/java/io/gravitee/kubernetes/client/spring/KubernetesClientConfiguration.java
@@ -30,7 +30,7 @@ import org.springframework.context.annotation.Configuration;
 public class KubernetesClientConfiguration {
 
     @Bean
-    public KubernetesClient kubernetesClient(Vertx vertx) {
-        return new KubernetesClientV1Impl(vertx);
+    public KubernetesClient kubernetesClient() {
+        return new KubernetesClientV1Impl();
     }
 }

--- a/gravitee-kubernetes-client/src/test/java/io/gravitee/kubernetes/client/KubernetesUnitTest.java
+++ b/gravitee-kubernetes-client/src/test/java/io/gravitee/kubernetes/client/KubernetesUnitTest.java
@@ -18,7 +18,6 @@ package io.gravitee.kubernetes.client;
 import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.gravitee.kubernetes.client.config.KubernetesConfig;
 import io.gravitee.kubernetes.client.impl.KubernetesClientV1Impl;
-import io.vertx.rxjava3.core.Vertx;
 import org.junit.After;
 import org.junit.Before;
 
@@ -29,7 +28,6 @@ import org.junit.Before;
 public abstract class KubernetesUnitTest {
 
     protected static final Long EVENT_WAIT_PERIOD_MS = 10L;
-    protected Vertx vertx = Vertx.vertx();
     protected KubernetesMockServer server;
     protected KubernetesClient kubernetesClient;
 
@@ -40,15 +38,12 @@ public abstract class KubernetesUnitTest {
 
         // Set kubeconfig system property to use for creating a
         buildKubernetesConfig();
-        kubernetesClient = new KubernetesClientV1Impl(vertx);
+        kubernetesClient = new KubernetesClientV1Impl();
     }
 
     @After
     public void after() {
-        vertx.exceptionHandler(null);
-        //    kubernetesClient.stop();
         server.destroy();
-        vertx.close();
     }
 
     // Helper methods

--- a/gravitee-kubernetes-client/src/test/java/io/gravitee/kubernetes/client/api/WatchQueryTest.java
+++ b/gravitee-kubernetes-client/src/test/java/io/gravitee/kubernetes/client/api/WatchQueryTest.java
@@ -24,24 +24,27 @@ import org.junit.jupiter.api.Test;
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author GraviteeSource Team
  */
-public class WatchQueryTest {
+class WatchQueryTest {
 
     @Test
-    public void shouldWatchSingleSecret() {
+    void shouldWatchSingleSecret() {
         WatchQuery<Event<Secret>> query = WatchQuery.secret("my-namespace", "my-secret-name").build();
 
-        Assertions.assertEquals("/api/v1/namespaces/my-namespace/secrets/my-secret-name?watch=true", query.toUri());
+        Assertions.assertEquals(
+            "/api/v1/namespaces/my-namespace/secrets?fieldSelector=metadata.name%3Dmy-secret-name&watch=true",
+            query.toUri()
+        );
     }
 
     @Test
-    public void shouldWatchSecretsFromAllNamespaces() {
+    void shouldWatchSecretsFromAllNamespaces() {
         WatchQuery<Event<Secret>> query = WatchQuery.secrets().build();
 
         Assertions.assertEquals("/api/v1/secrets?watch=true", query.toUri());
     }
 
     @Test
-    public void shouldWatchSecretsFromNamespace() {
+    void shouldWatchSecretsFromNamespace() {
         WatchQuery<Event<Secret>> query = WatchQuery.secrets("my-namespace").build();
 
         Assertions.assertEquals("/api/v1/namespaces/my-namespace/secrets?watch=true", query.toUri());
@@ -55,14 +58,14 @@ public class WatchQueryTest {
     }
 
     @Test
-    public void shouldGetSecretsFromNamespace_fieldSelector_usingFrom() {
+    void shouldGetSecretsFromNamespace_fieldSelector_usingFrom() {
         WatchQuery<Event<Secret>> query = WatchQuery
             .<Secret>from("/my-namespace/secrets")
             .fieldSelector(FieldSelector.equals("status.hostIP", "172.17.8.101"))
             .build();
 
         Assertions.assertEquals(
-            "/api/v1/namespaces/my-namespace/secrets?fieldSelector=status.hostIP=172.17.8.101&watch=true",
+            "/api/v1/namespaces/my-namespace/secrets?fieldSelector=status.hostIP%3D172.17.8.101&watch=true",
             query.toUri()
         );
     }

--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,7 @@
                 <artifactId>prettier-maven-plugin</artifactId>
                 <version>0.18</version>
                 <configuration>
-                    <nodeVersion>12.13.0</nodeVersion>
+                    <nodeVersion>16.16.0</nodeVersion>
                     <prettierJavaVersion>1.6.1</prettierJavaVersion>
                 </configuration>
                 <executions>


### PR DESCRIPTION
When a Kubernetes KeystoreManager blocks the event loop waiting for the client to resolve a secret, a deadlock occurs because the client itself relies on the same vertx instance as the KeystoreManager. 

similar as https://github.com/gravitee-io/gravitee-node/pull/188
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.0.2-fix-kubernetes-client-deadlock-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/kubernetes/gravitee-kubernetes/2.0.2-fix-kubernetes-client-deadlock-SNAPSHOT/gravitee-kubernetes-2.0.2-fix-kubernetes-client-deadlock-SNAPSHOT.zip)
  <!-- Version placeholder end -->
