### PR TITLE
fix: add ownerReferences to the ObjectMeta

### DIFF
--- a/gravitee-kubernetes-client/src/main/java/io/gravitee/kubernetes/client/model/v1/ObjectMeta.java
+++ b/gravitee-kubernetes-client/src/main/java/io/gravitee/kubernetes/client/model/v1/ObjectMeta.java
@@ -42,6 +42,7 @@ public class ObjectMeta {
     private String resourceVersion;
     private String selfLink;
     private String uid;
+    private List<OwnerReference> ownerReferences;
 
     /**
      * No args constructor for use in serialization
@@ -65,6 +66,7 @@ public class ObjectMeta {
      * @param creationTimestamp
      * @param name
      * @param namespace
+     * @param ownerReferences
      */
     public ObjectMeta(
         Map<String, String> annotations,
@@ -80,7 +82,8 @@ public class ObjectMeta {
         String namespace,
         String resourceVersion,
         String selfLink,
-        String uid
+        String uid,
+        List<OwnerReference> ownerReferences
     ) {
         super();
         this.annotations = annotations;
@@ -97,6 +100,7 @@ public class ObjectMeta {
         this.resourceVersion = resourceVersion;
         this.selfLink = selfLink;
         this.uid = uid;
+        this.setOwnerReferences(ownerReferences);
     }
 
     public Map<String, String> getAnnotations() {
@@ -211,6 +215,14 @@ public class ObjectMeta {
         this.uid = uid;
     }
 
+    public List<OwnerReference> getOwnerReferences() {
+        return ownerReferences;
+    }
+
+    public void setOwnerReferences(List<OwnerReference> ownerReferences) {
+        this.ownerReferences = ownerReferences;
+    }
+
     @Override
     public String toString() {
         return (
@@ -251,6 +263,9 @@ public class ObjectMeta {
             '\'' +
             ", uid='" +
             uid +
+            '\'' +
+            ", ownerReferences='" +
+            ownerReferences +
             '\'' +
             '}'
         );

--- a/gravitee-kubernetes-client/src/main/java/io/gravitee/kubernetes/client/model/v1/OwnerReference.java
+++ b/gravitee-kubernetes-client/src/main/java/io/gravitee/kubernetes/client/model/v1/OwnerReference.java
@@ -1,0 +1,105 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.kubernetes.client.model.v1;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/**
+ * @author Kamiel Ahmadpour (kamiel.ahmadpour at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class OwnerReference {
+
+    private String apiVersion;
+    private Boolean blockOwnerDeletion;
+    private Boolean controller;
+    private String kind;
+    private String name;
+    private String uid;
+
+    public String getApiVersion() {
+        return apiVersion;
+    }
+
+    public void setApiVersion(String apiVersion) {
+        this.apiVersion = apiVersion;
+    }
+
+    public Boolean getBlockOwnerDeletion() {
+        return blockOwnerDeletion;
+    }
+
+    public void setBlockOwnerDeletion(Boolean blockOwnerDeletion) {
+        this.blockOwnerDeletion = blockOwnerDeletion;
+    }
+
+    public Boolean getController() {
+        return controller;
+    }
+
+    public void setController(Boolean controller) {
+        this.controller = controller;
+    }
+
+    public String getKind() {
+        return kind;
+    }
+
+    public void setKind(String kind) {
+        this.kind = kind;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getUid() {
+        return uid;
+    }
+
+    public void setUid(String uid) {
+        this.uid = uid;
+    }
+
+    @Override
+    public String toString() {
+        return (
+            "OwnerReference{" +
+            "apiVersion='" +
+            apiVersion +
+            '\'' +
+            ", blockOwnerDeletion=" +
+            blockOwnerDeletion +
+            ", controller=" +
+            controller +
+            ", kind='" +
+            kind +
+            '\'' +
+            ", name='" +
+            name +
+            '\'' +
+            ", uid='" +
+            uid +
+            '\'' +
+            '}'
+        );
+    }
+}


### PR DESCRIPTION
**Issue**
add missing ownerReferences to the ObjectMeta

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `0.4.2-owner-reference-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/kubernetes/gravitee-kubernetes/0.4.2-owner-reference-SNAPSHOT/gravitee-kubernetes-0.4.2-owner-reference-SNAPSHOT.zip)
  <!-- Version placeholder end -->
