### PR TITLE
fix: ensure custom resources names are rfc 1123 compliant

### DIFF
--- a/gravitee-kubernetes-mapper/src/main/java/io/gravitee/kubernetes/mapper/ObjectMeta.java
+++ b/gravitee-kubernetes-mapper/src/main/java/io/gravitee/kubernetes/mapper/ObjectMeta.java
@@ -28,7 +28,7 @@ public class ObjectMeta {
     private final Map<String, String> labels = new HashMap<>();
 
     public ObjectMeta(String name) {
-        this.name = name;
+        this.name = sanitizeName(name);
     }
 
     public String getName() {
@@ -49,5 +49,9 @@ public class ObjectMeta {
 
     public void addAnnotation(String annotation, String value) {
         annotations.put(annotation, value);
+    }
+
+    private String sanitizeName(String name) {
+        return name.toLowerCase().replaceAll("[\\s_]", "-").replaceAll("[^-.a-z0-9]", "");
     }
 }

--- a/gravitee-kubernetes-mapper/src/test/java/ObjectMetaTest.java
+++ b/gravitee-kubernetes-mapper/src/test/java/ObjectMetaTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import static org.junit.Assert.assertEquals;
+
+import io.gravitee.kubernetes.mapper.ObjectMeta;
+import org.junit.Test;
+
+/**
+ * @author Antoine CORDIER (antoine.cordier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class ObjectMetaTest {
+
+    @Test
+    public void shouldSanitizeName() {
+        var meta = new ObjectMeta("Some_invalid @RFC-1123 name!");
+        assertEquals("some-invalid-rfc-1123-name", meta.getName());
+    }
+
+    @Test
+    public void shouldNotChangeName() {
+        var meta = new ObjectMeta("some-valid.rfc.1123.name");
+        assertEquals("some-valid.rfc.1123.name", meta.getName());
+    }
+}


### PR DESCRIPTION
see https://gravitee.atlassian.net/browse/GKO-210

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.2.1-gko-210-fix-k8s-generated-name-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/kubernetes/gravitee-kubernetes/3.2.1-gko-210-fix-k8s-generated-name-SNAPSHOT/gravitee-kubernetes-3.2.1-gko-210-fix-k8s-generated-name-SNAPSHOT.zip)
  <!-- Version placeholder end -->
