### PR TITLE
fix: skip processing up to date config maps on reconnect

### DIFF
--- a/gravitee-kubernetes-client/src/main/java/io/gravitee/kubernetes/client/model/v1/ConfigMap.java
+++ b/gravitee-kubernetes-client/src/main/java/io/gravitee/kubernetes/client/model/v1/ConfigMap.java
@@ -144,4 +144,9 @@ public class ConfigMap implements Serializable, Watchable {
             '}'
         );
     }
+
+    @Override
+    public ObjectMeta metaData() {
+        return this.metadata;
+    }
 }

--- a/gravitee-kubernetes-client/src/main/java/io/gravitee/kubernetes/client/model/v1/Secret.java
+++ b/gravitee-kubernetes-client/src/main/java/io/gravitee/kubernetes/client/model/v1/Secret.java
@@ -135,4 +135,9 @@ public class Secret implements Serializable, Watchable {
             '}'
         );
     }
+
+    @Override
+    public ObjectMeta metaData() {
+        return this.metadata;
+    }
 }

--- a/gravitee-kubernetes-client/src/main/java/io/gravitee/kubernetes/client/model/v1/Watchable.java
+++ b/gravitee-kubernetes-client/src/main/java/io/gravitee/kubernetes/client/model/v1/Watchable.java
@@ -15,4 +15,6 @@
  */
 package io.gravitee.kubernetes.client.model.v1;
 
-public interface Watchable {}
+public interface Watchable {
+    ObjectMeta metaData();
+}

--- a/gravitee-kubernetes-client/src/test/java/io/gravitee/kubernetes/client/KubernetesConfigMapV1Test.java
+++ b/gravitee-kubernetes-client/src/test/java/io/gravitee/kubernetes/client/KubernetesConfigMapV1Test.java
@@ -15,11 +15,7 @@
  */
 package io.gravitee.kubernetes.client;
 
-import io.fabric8.kubernetes.api.model.ConfigMap;
-import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
-import io.fabric8.kubernetes.api.model.ConfigMapListBuilder;
-import io.fabric8.kubernetes.api.model.ObjectMeta;
-import io.fabric8.kubernetes.api.model.WatchEvent;
+import io.fabric8.kubernetes.api.model.*;
 import io.gravitee.kubernetes.client.api.ResourceQuery;
 import io.gravitee.kubernetes.client.api.WatchQuery;
 import io.gravitee.kubernetes.client.model.v1.Watchable;
@@ -149,7 +145,7 @@ public class KubernetesConfigMapV1Test extends KubernetesUnitTest {
             .immediately()
             .andEmit(new WatchEvent(configMap3, "ADDED"))
             .waitFor(EVENT_WAIT_PERIOD_MS)
-            .andEmit(new WatchEvent(configMap1, "MODIFIED"))
+            .andEmit(new WatchEvent(incrementResourceVersion(configMap1), "MODIFIED"))
             .done()
             .once();
 
@@ -183,7 +179,7 @@ public class KubernetesConfigMapV1Test extends KubernetesUnitTest {
             .immediately()
             .andEmit(new WatchEvent(configMap3, "ADDED"))
             .waitFor(EVENT_WAIT_PERIOD_MS)
-            .andEmit(new WatchEvent(configMap1, "MODIFIED"))
+            .andEmit(new WatchEvent(incrementResourceVersion(configMap1), "MODIFIED"))
             .done()
             .once();
 
@@ -207,7 +203,7 @@ public class KubernetesConfigMapV1Test extends KubernetesUnitTest {
             .waitFor(EVENT_WAIT_PERIOD_MS)
             .andEmit(new WatchEvent(configMap1, "MODIFIED"))
             .waitFor(EVENT_WAIT_PERIOD_MS)
-            .andEmit(new WatchEvent(configMap1, "DELETED"))
+            .andEmit(new WatchEvent(incrementResourceVersion(configMap1), "DELETED"))
             .done()
             .once();
 
@@ -233,7 +229,7 @@ public class KubernetesConfigMapV1Test extends KubernetesUnitTest {
             .waitFor(EVENT_WAIT_PERIOD_MS)
             .andEmit(new WatchEvent(configMap1, "MODIFIED"))
             .waitFor(EVENT_WAIT_PERIOD_MS)
-            .andEmit(new WatchEvent(configMap1, "ERROR"))
+            .andEmit(new WatchEvent(incrementResourceVersion(configMap1), "ERROR"))
             .done()
             .once();
 
@@ -349,11 +345,18 @@ public class KubernetesConfigMapV1Test extends KubernetesUnitTest {
         metadata.setNamespace("test");
         metadata.setName(name);
         metadata.setUid(uid);
+        metadata.setResourceVersion("1");
 
         ConfigMap configMap = new ConfigMap();
         configMap.setMetadata(metadata);
         configMap.setData(data);
 
+        return configMap;
+    }
+
+    private ConfigMap incrementResourceVersion(ConfigMap configMap) {
+        int i = Integer.parseInt(configMap.getMetadata().getResourceVersion());
+        configMap.getMetadata().setResourceVersion(String.valueOf(i + 1));
         return configMap;
     }
 }

--- a/gravitee-kubernetes-client/src/test/java/io/gravitee/kubernetes/client/KubernetesSecretV1Test.java
+++ b/gravitee-kubernetes-client/src/test/java/io/gravitee/kubernetes/client/KubernetesSecretV1Test.java
@@ -31,10 +31,7 @@ import io.reactivex.rxjava3.observers.TestObserver;
 import io.reactivex.rxjava3.subscribers.TestSubscriber;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
+import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.Before;
@@ -157,7 +154,7 @@ public class KubernetesSecretV1Test extends KubernetesUnitTest {
             .waitFor(EVENT_WAIT_PERIOD_MS)
             .andEmit(new WatchEvent(secret3, "ADDED"))
             .waitFor(EVENT_WAIT_PERIOD_MS)
-            .andEmit(new WatchEvent(secret1, "MODIFIED"))
+            .andEmit(new WatchEvent(incrementResourceVersion(secret1), "MODIFIED"))
             .done()
             .once();
 
@@ -184,7 +181,7 @@ public class KubernetesSecretV1Test extends KubernetesUnitTest {
             .waitFor(EVENT_WAIT_PERIOD_MS)
             .andEmit(new WatchEvent(secret1, "MODIFIED"))
             .waitFor(EVENT_WAIT_PERIOD_MS)
-            .andEmit(new WatchEvent(secret1, "DELETED"))
+            .andEmit(new WatchEvent(incrementResourceVersion(secret1), "DELETED"))
             .done()
             .once();
 
@@ -214,7 +211,7 @@ public class KubernetesSecretV1Test extends KubernetesUnitTest {
             .waitFor(EVENT_WAIT_PERIOD_MS)
             .andEmit(new WatchEvent(secret1, "MODIFIED"))
             .waitFor(EVENT_WAIT_PERIOD_MS)
-            .andEmit(new WatchEvent(secret1, "DELETED"))
+            .andEmit(new WatchEvent(incrementResourceVersion(secret1), "DELETED"))
             .done()
             .once();
 
@@ -240,7 +237,7 @@ public class KubernetesSecretV1Test extends KubernetesUnitTest {
             .waitFor(EVENT_WAIT_PERIOD_MS)
             .andEmit(new WatchEvent(secret1, "MODIFIED"))
             .waitFor(EVENT_WAIT_PERIOD_MS)
-            .andEmit(new WatchEvent(secret1, "DELETED"))
+            .andEmit(new WatchEvent(incrementResourceVersion(secret1), "DELETED"))
             .done()
             .once();
 
@@ -264,7 +261,7 @@ public class KubernetesSecretV1Test extends KubernetesUnitTest {
             .waitFor(EVENT_WAIT_PERIOD_MS)
             .andEmit(new WatchEvent(secret1, "MODIFIED"))
             .waitFor(EVENT_WAIT_PERIOD_MS)
-            .andEmit(new WatchEvent(secret1, "DELETED"))
+            .andEmit(new WatchEvent(incrementResourceVersion(secret1), "DELETED"))
             .done()
             .once();
 
@@ -328,7 +325,7 @@ public class KubernetesSecretV1Test extends KubernetesUnitTest {
             .waitFor(EVENT_WAIT_PERIOD_MS)
             .andEmit(new WatchEvent(secret1, "MODIFIED"))
             .waitFor(EVENT_WAIT_PERIOD_MS)
-            .andEmit(new WatchEvent(secret1, "DELETED"))
+            .andEmit(new WatchEvent(incrementResourceVersion(secret1), "DELETED"))
             .done()
             .once();
 
@@ -363,7 +360,7 @@ public class KubernetesSecretV1Test extends KubernetesUnitTest {
             .waitFor(EVENT_WAIT_PERIOD_MS)
             .andEmit(new WatchEvent(secret1, "MODIFIED"))
             .waitFor(EVENT_WAIT_PERIOD_MS)
-            .andEmit(new WatchEvent(secret1, "DELETED"))
+            .andEmit(new WatchEvent(incrementResourceVersion(secret1), "DELETED"))
             .done()
             .once();
 
@@ -429,7 +426,7 @@ public class KubernetesSecretV1Test extends KubernetesUnitTest {
             .waitFor(EVENT_WAIT_PERIOD_MS)
             .andEmit(new WatchEvent(secret1, "ADDED"))
             .waitFor(EVENT_WAIT_PERIOD_MS)
-            .andEmit(new WatchEvent(secret1, "ERROR"))
+            .andEmit(new WatchEvent(incrementResourceVersion(secret1), "ERROR"))
             .done()
             .once();
 
@@ -441,7 +438,7 @@ public class KubernetesSecretV1Test extends KubernetesUnitTest {
             .andUpgradeToWebSocket()
             .open()
             .waitFor(EVENT_WAIT_PERIOD_MS)
-            .andEmit(new WatchEvent(secret1, "MODIFIED"))
+            .andEmit(new WatchEvent(incrementResourceVersion(secret1), "MODIFIED"))
             .done()
             .once();
 
@@ -520,12 +517,19 @@ public class KubernetesSecretV1Test extends KubernetesUnitTest {
         metadata.setNamespace(namespace);
         metadata.setName(name);
         metadata.setUid(uid);
+        metadata.setResourceVersion("1");
 
         Secret secret = new Secret();
         secret.setMetadata(metadata);
         secret.setData(data);
         secret.setApiVersion("1.0");
 
+        return secret;
+    }
+
+    private Secret incrementResourceVersion(Secret secret) {
+        int i = Integer.parseInt(secret.getMetadata().getResourceVersion());
+        secret.getMetadata().setResourceVersion(String.valueOf(i + 1));
         return secret;
     }
 }


### PR DESCRIPTION
see https://gravitee.atlassian.net/browse/GKO-127

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.3.1-GKO-127-skip-existing-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/kubernetes/gravitee-kubernetes/3.3.1-GKO-127-skip-existing-SNAPSHOT/gravitee-kubernetes-3.3.1-GKO-127-skip-existing-SNAPSHOT.zip)
  <!-- Version placeholder end -->
