### PR TITLE
feat: allow to pass resource version for list and watch

### DIFF
--- a/gravitee-kubernetes-client/src/main/java/io/gravitee/kubernetes/client/api/AbstractQuery.java
+++ b/gravitee-kubernetes-client/src/main/java/io/gravitee/kubernetes/client/api/AbstractQuery.java
@@ -18,6 +18,7 @@ package io.gravitee.kubernetes.client.api;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import lombok.Getter;
 import org.springframework.util.StringUtils;
 
 /**
@@ -29,9 +30,19 @@ class AbstractQuery<T> {
     private static final String API_VERSION = "/api/v1";
 
     protected final Type type;
+
+    @Getter
     protected final String namespace;
+
+    @Getter
     protected final String resource;
+
+    @Getter
     protected final String resourceKey;
+
+    @Getter
+    protected final String resourceVersion;
+
     protected final List<FieldSelector> fieldSelectors;
     protected final List<LabelSelector> labelSelectors;
 
@@ -40,6 +51,7 @@ class AbstractQuery<T> {
         Type type,
         String resource,
         String resourceKey,
+        String resourceVersion,
         List<FieldSelector> fieldSelectors,
         List<LabelSelector> labelSelectors
     ) {
@@ -47,6 +59,7 @@ class AbstractQuery<T> {
         this.namespace = namespace;
         this.resource = resource;
         this.resourceKey = resourceKey;
+        this.resourceVersion = resourceVersion;
         this.fieldSelectors = fieldSelectors;
         this.labelSelectors = labelSelectors;
     }
@@ -57,18 +70,6 @@ class AbstractQuery<T> {
         } else {
             return (Class<T>) this.type.listType();
         }
-    }
-
-    public String getResource() {
-        return resource;
-    }
-
-    public String getNamespace() {
-        return namespace;
-    }
-
-    public String getResourceKey() {
-        return resourceKey;
     }
 
     private boolean singleResource() {
@@ -115,6 +116,10 @@ class AbstractQuery<T> {
             parameters.add(labelSelectorBuilder.toString());
         }
 
+        if (resourceVersion != null && !resourceVersion.isEmpty()) {
+            parameters.add("resourceVersion=" + resourceVersion);
+        }
+
         return parameters;
     }
 
@@ -151,6 +156,7 @@ class AbstractQuery<T> {
         protected String namespace;
         protected String resource;
         protected String resourceKey;
+        protected String resourceVersion;
         protected final List<FieldSelector> fieldSelectors = new ArrayList<>();
         protected final List<LabelSelector> labelSelectors = new ArrayList<>();
 
@@ -180,6 +186,11 @@ class AbstractQuery<T> {
 
         public AbstractQueryBuilder<T> resourceKey(String resourceKey) {
             this.resourceKey = resourceKey;
+            return this;
+        }
+
+        public AbstractQueryBuilder<T> resourceVersion(String resourceVersion) {
+            this.resourceVersion = resourceVersion;
             return this;
         }
     }

--- a/gravitee-kubernetes-client/src/main/java/io/gravitee/kubernetes/client/api/ResourceQuery.java
+++ b/gravitee-kubernetes-client/src/main/java/io/gravitee/kubernetes/client/api/ResourceQuery.java
@@ -32,10 +32,11 @@ public class ResourceQuery<T> extends AbstractQuery<T> {
         Type type,
         String resource,
         String resourceKey,
+        String resourceVersion,
         List<FieldSelector> fieldSelectors,
         List<LabelSelector> labelSelectors
     ) {
-        super(namespace, type, resource, resourceKey, fieldSelectors, labelSelectors);
+        super(namespace, type, resource, resourceKey, resourceVersion, fieldSelectors, labelSelectors);
     }
 
     public static QueryBuilder<ConfigMapList> configMaps() {
@@ -113,8 +114,14 @@ public class ResourceQuery<T> extends AbstractQuery<T> {
             return this;
         }
 
+        @Override
+        public QueryBuilder<T> resourceVersion(String resourceVersion) {
+            super.resourceVersion(resourceVersion);
+            return this;
+        }
+
         public ResourceQuery<T> build() {
-            return new ResourceQuery<>(namespace, type, resource, resourceKey, fieldSelectors, labelSelectors);
+            return new ResourceQuery<>(namespace, type, resource, resourceKey, resourceVersion, fieldSelectors, labelSelectors);
         }
     }
 }

--- a/gravitee-kubernetes-client/src/main/java/io/gravitee/kubernetes/client/api/WatchQuery.java
+++ b/gravitee-kubernetes-client/src/main/java/io/gravitee/kubernetes/client/api/WatchQuery.java
@@ -35,11 +35,12 @@ public class WatchQuery<E extends Event<? extends Watchable>> extends AbstractQu
         Type type,
         String resource,
         String resourceKey,
+        String resourceVersion,
         List<FieldSelector> fieldSelectors,
         List<LabelSelector> labelSelectors,
         boolean allowWatchBookmarks
     ) {
-        super(namespace, type, resource, resourceKey, fieldSelectors, labelSelectors);
+        super(namespace, type, resource, resourceKey, resourceVersion, fieldSelectors, labelSelectors);
         this.allowWatchBookmarks = allowWatchBookmarks;
     }
 
@@ -141,13 +142,28 @@ public class WatchQuery<E extends Event<? extends Watchable>> extends AbstractQu
             return this;
         }
 
+        @Override
+        public WatchQueryBuilder<T, E> resourceVersion(String resourceVersion) {
+            super.resourceVersion(resourceVersion);
+            return this;
+        }
+
         public WatchQueryBuilder<T, E> allowWatchBookmarks(boolean allowWatchBookmarks) {
             this.allowWatchBookmarks = allowWatchBookmarks;
             return this;
         }
 
         public WatchQuery<E> build() {
-            return new WatchQuery<>(namespace, type, resource, resourceKey, fieldSelectors, labelSelectors, allowWatchBookmarks);
+            return new WatchQuery<>(
+                namespace,
+                type,
+                resource,
+                resourceKey,
+                resourceVersion,
+                fieldSelectors,
+                labelSelectors,
+                allowWatchBookmarks
+            );
         }
     }
 }

--- a/gravitee-kubernetes-client/src/main/java/io/gravitee/kubernetes/client/exception/ResourceVersionNotFoundException.java
+++ b/gravitee-kubernetes-client/src/main/java/io/gravitee/kubernetes/client/exception/ResourceVersionNotFoundException.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.kubernetes.client.exception;
+
+/**
+ * @author Antoine CORDIER (antoine.cordier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class ResourceVersionNotFoundException extends RuntimeException {
+
+    public ResourceVersionNotFoundException(String resourceVersion) {
+        super(String.format("Resource version %s is not recognized anymore. Any cache using it should be cleared", resourceVersion));
+    }
+}

--- a/gravitee-kubernetes-client/src/main/java/io/gravitee/kubernetes/client/impl/KubernetesClientV1Impl.java
+++ b/gravitee-kubernetes-client/src/main/java/io/gravitee/kubernetes/client/impl/KubernetesClientV1Impl.java
@@ -24,6 +24,7 @@ import io.gravitee.kubernetes.client.api.ResourceQuery;
 import io.gravitee.kubernetes.client.api.WatchQuery;
 import io.gravitee.kubernetes.client.config.KubernetesConfig;
 import io.gravitee.kubernetes.client.exception.ResourceNotFoundException;
+import io.gravitee.kubernetes.client.exception.ResourceVersionNotFoundException;
 import io.gravitee.kubernetes.client.model.v1.*;
 import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.core.FlowableTransformer;
@@ -140,6 +141,10 @@ public class KubernetesClientV1Impl implements KubernetesClient {
                 if (response.statusCode() != 200) {
                     if (response.statusCode() == 404) {
                         return Maybe.error(new ResourceNotFoundException("Can't find resource at " + uri));
+                    }
+
+                    if (response.statusCode() == 410) {
+                        return Maybe.error(new ResourceVersionNotFoundException(query.getResourceVersion()));
                     }
 
                     return Maybe.error(


### PR DESCRIPTION
see https://gravitee.atlassian.net/browse/GKO-175

The idea here is to be able to pass a resource version to the Kubernetes API server for get and watch operations in order to implement a list then watch pattern as required by this issue 👆 

see https://kubernetes.io/docs/reference/using-api/api-concepts/#efficient-detection-of-changes

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.4.0-feat-use-resource-version-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/kubernetes/gravitee-kubernetes/3.4.0-feat-use-resource-version-SNAPSHOT/gravitee-kubernetes-3.4.0-feat-use-resource-version-SNAPSHOT.zip)
  <!-- Version placeholder end -->
