### PR TITLE
fix: solve the issue NPE on old resource versions

### DIFF
--- a/gravitee-kubernetes-client/src/main/java/io/gravitee/kubernetes/client/model/v1/Error.java
+++ b/gravitee-kubernetes-client/src/main/java/io/gravitee/kubernetes/client/model/v1/Error.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.kubernetes.client.model.v1;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * @author Kamiel Ahmadpour (kamiel.ahmadpour at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@Setter
+@Getter
+public class Error {
+
+    private String type;
+    private ErrorObject object;
+
+    @Getter
+    @Setter
+    public static class ErrorObject {
+
+        private String kind;
+        private String apiVersion;
+        private Object metadata;
+        private String status;
+        private String message;
+        private String reason;
+        private int code;
+    }
+}


### PR DESCRIPTION
see: https://gravitee.atlassian.net/browse/GKO-672


<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.4.1-GKO-672-NPE-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/kubernetes/gravitee-kubernetes/3.4.1-GKO-672-NPE-SNAPSHOT/gravitee-kubernetes-3.4.1-GKO-672-NPE-SNAPSHOT.zip)
  <!-- Version placeholder end -->
