### PR TITLE
feat: support watch with wildcard

### DIFF
--- a/gravitee-kubernetes-client/src/main/java/io/gravitee/kubernetes/client/api/AbstractQuery.java
+++ b/gravitee-kubernetes-client/src/main/java/io/gravitee/kubernetes/client/api/AbstractQuery.java
@@ -25,7 +25,7 @@ import org.springframework.util.StringUtils;
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author GraviteeSource Team
  */
-class AbstractQuery<T> {
+abstract class AbstractQuery<T> {
 
     private static final String API_VERSION = "/api/v1";
 
@@ -72,7 +72,9 @@ class AbstractQuery<T> {
         }
     }
 
-    private boolean singleResource() {
+    protected abstract String uriResource();
+
+    protected boolean singleResource() {
         return resource != null && !resource.isEmpty();
     }
 
@@ -86,9 +88,8 @@ class AbstractQuery<T> {
 
         builder.append('/').append(type.value());
 
-        if (singleResource()) {
-            builder.append('/').append(resource);
-        }
+        // Append resource to uri if applicable.
+        builder.append(uriResource());
 
         // Build parameters
         List<String> parameters = buildParameters();

--- a/gravitee-kubernetes-client/src/main/java/io/gravitee/kubernetes/client/api/ResourceQuery.java
+++ b/gravitee-kubernetes-client/src/main/java/io/gravitee/kubernetes/client/api/ResourceQuery.java
@@ -39,6 +39,11 @@ public class ResourceQuery<T> extends AbstractQuery<T> {
         super(namespace, type, resource, resourceKey, resourceVersion, fieldSelectors, labelSelectors);
     }
 
+    @Override
+    protected String uriResource() {
+        return singleResource() ? "/" + resource : "";
+    }
+
     public static QueryBuilder<ConfigMapList> configMaps() {
         return new QueryBuilder<>(Type.CONFIGMAPS);
     }

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>22.2.5</version>
+        <version>22.5.0</version>
     </parent>
 
     <groupId>io.gravitee.kubernetes</groupId>


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/ARCHI-528

**Description**

This PR allows for watching a set of resources using a wildcard.
The primary objective is to allow for configuring TLS using a wildcard secret. That way, it becomes possible to load several secrets as soon as they are created and match the wildcard. 

Ex: the following watch for all the secrets named `gravitee-*-tls`

```yaml
http:
  secured: true
  ssl:
    keystore:
      secret: secret://kubernetes/gravitee-*-tls-secret?resolveBeforeWatch=false
      watch: true
```

Note: wildcard is only supported in watch, trying to use a wildcard without watching will fail with a "not found".
Note2: resolveBeforeWatch must be disabled as getting a resource with a wildcard isn't supported (cf: note 1).

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.6.0-archi-528-support-multi-tls-secrets-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/kubernetes/gravitee-kubernetes/3.6.0-archi-528-support-multi-tls-secrets-SNAPSHOT/gravitee-kubernetes-3.6.0-archi-528-support-multi-tls-secrets-SNAPSHOT.zip)
  <!-- Version placeholder end -->
