### PR TITLE
feat: add EndpointSlice support to kubernetes client

### DIFF
--- a/gravitee-kubernetes-client/src/main/java/io/gravitee/kubernetes/client/api/AbstractQuery.java
+++ b/gravitee-kubernetes-client/src/main/java/io/gravitee/kubernetes/client/api/AbstractQuery.java
@@ -27,7 +27,6 @@ import org.springframework.util.StringUtils;
  */
 abstract class AbstractQuery<T> {
 
-
     protected final Type type;
 
     @Getter

--- a/gravitee-kubernetes-client/src/main/java/io/gravitee/kubernetes/client/api/AbstractQuery.java
+++ b/gravitee-kubernetes-client/src/main/java/io/gravitee/kubernetes/client/api/AbstractQuery.java
@@ -27,7 +27,6 @@ import org.springframework.util.StringUtils;
  */
 abstract class AbstractQuery<T> {
 
-    private static final String API_VERSION = "/api/v1";
 
     protected final Type type;
 
@@ -82,7 +81,7 @@ abstract class AbstractQuery<T> {
     }
 
     public String toUri() {
-        StringBuilder builder = new StringBuilder(API_VERSION);
+        StringBuilder builder = new StringBuilder(type.apiBase());
 
         // Build uri
         if (namespace != null && !namespace.isEmpty()) {

--- a/gravitee-kubernetes-client/src/main/java/io/gravitee/kubernetes/client/api/ResourceQuery.java
+++ b/gravitee-kubernetes-client/src/main/java/io/gravitee/kubernetes/client/api/ResourceQuery.java
@@ -59,6 +59,21 @@ public class ResourceQuery<T> extends AbstractQuery<T> {
         return new QueryBuilder<EndpointsList>(Type.ENDPOINTS).namespace(namespace).resource(endpointsName);
     }
 
+    public static QueryBuilder<EndpointSliceList> endpointSlices() {
+        return new QueryBuilder<>(Type.ENDPOINTSLICES);
+    }
+
+    public static QueryBuilder<EndpointSliceList> endpointSlices(String namespace) {
+        Objects.requireNonNull(namespace, NAMESPACE_CAN_NOT_BE_NULL);
+        return new QueryBuilder<EndpointSliceList>(Type.ENDPOINTSLICES).namespace(namespace);
+    }
+
+    public static QueryBuilder<EndpointSliceList> endpointSlices(String namespace, String endpointSliceName) {
+        Objects.requireNonNull(namespace, NAMESPACE_CAN_NOT_BE_NULL);
+        Objects.requireNonNull(endpointSliceName, "EndpointSlice name can not be null");
+        return new QueryBuilder<EndpointSliceList>(Type.ENDPOINTSLICES).namespace(namespace).resource(endpointSliceName);
+    }
+
     public static QueryBuilder<ConfigMapList> configMaps() {
         return new QueryBuilder<>(Type.CONFIGMAPS);
     }

--- a/gravitee-kubernetes-client/src/main/java/io/gravitee/kubernetes/client/api/Type.java
+++ b/gravitee-kubernetes-client/src/main/java/io/gravitee/kubernetes/client/api/Type.java
@@ -22,21 +22,27 @@ import io.gravitee.kubernetes.client.model.v1.*;
  * @author GraviteeSource Team
  */
 public enum Type {
-    ENDPOINTS("endpoints", Endpoints.class, EndpointsList.class, EndpointsEvent.class),
-    ENDPOINTSLICES("endpointslices", EndpointSlice.class, EndpointSliceList.class, EndpointSliceEvent.class),
-    SECRETS("secrets", Secret.class, SecretList.class, SecretEvent.class),
-    CONFIGMAPS("configmaps", ConfigMap.class, ConfigMapList.class, ConfigMapEvent.class);
+    ENDPOINTS("/api/v1", "endpoints", Endpoints.class, EndpointsList.class, EndpointsEvent.class),
+    ENDPOINTSLICES("/apis/discovery.k8s.io/v1", "endpointslices", EndpointSlice.class, EndpointSliceList.class, EndpointSliceEvent.class),
+    SECRETS("/api/v1", "secrets", Secret.class, SecretList.class, SecretEvent.class),
+    CONFIGMAPS("/api/v1", "configmaps", ConfigMap.class, ConfigMapList.class, ConfigMapEvent.class);
 
+    private final String apiBase;
     private final String value;
     private final Class<?> clazz;
     private final Class<?> listType;
     private final Class<? extends Event<Watchable>> eventType;
 
-    Type(String value, Class<?> clazz, Class<?> listType, Class<? extends Event<?>> eventType) {
+    Type(String apiBase, String value, Class<?> clazz, Class<?> listType, Class<? extends Event<?>> eventType) {
+        this.apiBase = apiBase;
         this.value = value;
         this.clazz = clazz;
         this.listType = listType;
         this.eventType = (Class<? extends Event<Watchable>>) eventType;
+    }
+
+    public String apiBase() {
+        return apiBase;
     }
 
     public String value() {

--- a/gravitee-kubernetes-client/src/main/java/io/gravitee/kubernetes/client/api/Type.java
+++ b/gravitee-kubernetes-client/src/main/java/io/gravitee/kubernetes/client/api/Type.java
@@ -23,6 +23,7 @@ import io.gravitee.kubernetes.client.model.v1.*;
  */
 public enum Type {
     ENDPOINTS("endpoints", Endpoints.class, EndpointsList.class, EndpointsEvent.class),
+    ENDPOINTSLICES("endpointslices", EndpointSlice.class, EndpointSliceList.class, EndpointSliceEvent.class),
     SECRETS("secrets", Secret.class, SecretList.class, SecretEvent.class),
     CONFIGMAPS("configmaps", ConfigMap.class, ConfigMapList.class, ConfigMapEvent.class);
 

--- a/gravitee-kubernetes-client/src/main/java/io/gravitee/kubernetes/client/api/WatchQuery.java
+++ b/gravitee-kubernetes-client/src/main/java/io/gravitee/kubernetes/client/api/WatchQuery.java
@@ -53,6 +53,15 @@ public class WatchQuery<E extends Event<? extends Watchable>> extends AbstractQu
         return new WatchQueryBuilder<Endpoints, Event<Endpoints>>(Type.ENDPOINTS).namespace(namespace);
     }
 
+    public static WatchQueryBuilder<EndpointSlice, Event<EndpointSlice>> endpointSlices() {
+        return new WatchQueryBuilder<>(Type.ENDPOINTSLICES);
+    }
+
+    public static WatchQueryBuilder<EndpointSlice, Event<EndpointSlice>> endpointSlices(String namespace) {
+        Objects.requireNonNull(namespace, NAMESPACE_CAN_NOT_BE_NULL);
+        return new WatchQueryBuilder<EndpointSlice, Event<EndpointSlice>>(Type.ENDPOINTSLICES).namespace(namespace);
+    }
+
     public static WatchQueryBuilder<ConfigMap, Event<ConfigMap>> configMaps() {
         return new WatchQueryBuilder<>(Type.CONFIGMAPS);
     }

--- a/gravitee-kubernetes-client/src/main/java/io/gravitee/kubernetes/client/model/v1/EndpointSlice.java
+++ b/gravitee-kubernetes-client/src/main/java/io/gravitee/kubernetes/client/model/v1/EndpointSlice.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.kubernetes.client.model.v1;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.io.Serial;
+import java.io.Serializable;
+import java.util.List;
+import lombok.Data;
+
+/**
+ * @author GraviteeSource Team
+ */
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class EndpointSlice implements Serializable, Watchable {
+
+    @Serial
+    private static final long serialVersionUID = -4085686808007684134L;
+
+    @JsonProperty("metadata")
+    private ObjectMeta metadata;
+
+    @JsonProperty("addressType")
+    private String addressType;
+
+    @JsonProperty("endpoints")
+    private List<EndpointSliceEndpoint> endpoints;
+
+    @JsonProperty("ports")
+    private List<EndpointSlicePort> ports;
+
+    @Override
+    public ObjectMeta metaData() {
+        return metadata;
+    }
+}

--- a/gravitee-kubernetes-client/src/main/java/io/gravitee/kubernetes/client/model/v1/EndpointSliceConditions.java
+++ b/gravitee-kubernetes-client/src/main/java/io/gravitee/kubernetes/client/model/v1/EndpointSliceConditions.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.kubernetes.client.model.v1;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+
+/**
+ * @author GraviteeSource Team
+ */
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class EndpointSliceConditions {
+
+    @JsonProperty("ready")
+    private Boolean ready;
+
+    @JsonProperty("serving")
+    private Boolean serving;
+
+    @JsonProperty("terminating")
+    private Boolean terminating;
+}

--- a/gravitee-kubernetes-client/src/main/java/io/gravitee/kubernetes/client/model/v1/EndpointSliceEndpoint.java
+++ b/gravitee-kubernetes-client/src/main/java/io/gravitee/kubernetes/client/model/v1/EndpointSliceEndpoint.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.kubernetes.client.model.v1;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import lombok.Data;
+
+/**
+ * @author GraviteeSource Team
+ */
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class EndpointSliceEndpoint {
+
+    @JsonProperty("addresses")
+    private List<String> addresses;
+
+    @JsonProperty("conditions")
+    private EndpointSliceConditions conditions;
+}

--- a/gravitee-kubernetes-client/src/main/java/io/gravitee/kubernetes/client/model/v1/EndpointSliceEvent.java
+++ b/gravitee-kubernetes-client/src/main/java/io/gravitee/kubernetes/client/model/v1/EndpointSliceEvent.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.kubernetes.client.model.v1;
+
+/**
+ * @author GraviteeSource Team
+ */
+public class EndpointSliceEvent extends Event<EndpointSlice> {}

--- a/gravitee-kubernetes-client/src/main/java/io/gravitee/kubernetes/client/model/v1/EndpointSliceList.java
+++ b/gravitee-kubernetes-client/src/main/java/io/gravitee/kubernetes/client/model/v1/EndpointSliceList.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.kubernetes.client.model.v1;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * @author GraviteeSource Team
+ */
+@NoArgsConstructor
+@AllArgsConstructor
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class EndpointSliceList {
+
+    private String apiVersion = "discovery.k8s.io/v1";
+    private List<EndpointSlice> items = new ArrayList<>();
+    private String kind = "EndpointSliceList";
+    private ListMeta metadata;
+}

--- a/gravitee-kubernetes-client/src/main/java/io/gravitee/kubernetes/client/model/v1/EndpointSlicePort.java
+++ b/gravitee-kubernetes-client/src/main/java/io/gravitee/kubernetes/client/model/v1/EndpointSlicePort.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.kubernetes.client.model.v1;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+
+/**
+ * @author GraviteeSource Team
+ */
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class EndpointSlicePort {
+
+    @JsonProperty("name")
+    private String name;
+
+    @JsonProperty("protocol")
+    private String protocol;
+
+    @JsonProperty("port")
+    private Integer port;
+}

--- a/gravitee-kubernetes-client/src/test/java/io/gravitee/kubernetes/client/KubernetesEndpointSliceV1Test.java
+++ b/gravitee-kubernetes-client/src/test/java/io/gravitee/kubernetes/client/KubernetesEndpointSliceV1Test.java
@@ -21,7 +21,7 @@ import io.fabric8.kubernetes.api.model.discovery.EndpointSlice;
 import io.fabric8.kubernetes.api.model.discovery.EndpointSliceBuilder;
 import io.fabric8.kubernetes.api.model.discovery.EndpointSliceList;
 import io.fabric8.kubernetes.api.model.discovery.EndpointSliceListBuilder;
-import io.fabric8.kubernetes.api.model.discovery.EndpointSlicePortBuilder;
+import io.fabric8.kubernetes.api.model.discovery.EndpointPortBuilder;
 import io.gravitee.kubernetes.client.api.FieldSelector;
 import io.gravitee.kubernetes.client.api.LabelSelector;
 import io.gravitee.kubernetes.client.api.ResourceQuery;
@@ -132,7 +132,7 @@ public class KubernetesEndpointSliceV1Test extends KubernetesUnitTest {
         EndpointSlice slice = new EndpointSliceBuilder()
             .withMetadata(new ObjectMetaBuilder().withName("testEndpointSlice").withResourceVersion("1234").build())
             .withAddressType("IPv4")
-            .withPorts(new EndpointSlicePortBuilder().withPort(8080).build())
+            .withPorts(new EndpointPortBuilder().withPort(8080).build())
             .addNewEndpoint()
             .withAddresses("10.0.0.1")
             .endEndpoint()

--- a/gravitee-kubernetes-client/src/test/java/io/gravitee/kubernetes/client/KubernetesEndpointSliceV1Test.java
+++ b/gravitee-kubernetes-client/src/test/java/io/gravitee/kubernetes/client/KubernetesEndpointSliceV1Test.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.kubernetes.client;
+
+import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
+import io.fabric8.kubernetes.api.model.WatchEvent;
+import io.fabric8.kubernetes.api.model.discovery.EndpointSlice;
+import io.fabric8.kubernetes.api.model.discovery.EndpointSliceList;
+import io.fabric8.kubernetes.api.model.discovery.EndpointSliceListBuilder;
+import io.fabric8.kubernetes.api.model.discovery.EndpointSlicePortBuilder;
+import io.fabric8.kubernetes.api.model.discovery.EndpointSliceBuilder;
+import io.gravitee.kubernetes.client.api.FieldSelector;
+import io.gravitee.kubernetes.client.api.LabelSelector;
+import io.gravitee.kubernetes.client.api.ResourceQuery;
+import io.gravitee.kubernetes.client.api.WatchQuery;
+import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.observers.TestObserver;
+import io.reactivex.rxjava3.subscribers.TestSubscriber;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(VertxUnitRunner.class)
+public class KubernetesEndpointSliceV1Test extends KubernetesUnitTest {
+
+    @Test
+    public void should_get_endpointslice_list(TestContext tc) throws InterruptedException {
+        server
+            .expect()
+            .get()
+            .withPath("/apis/discovery.k8s.io/v1/namespaces/test/endpointslices")
+            .andReturn(200, buildEndpointSlices())
+            .always();
+
+        final TestObserver<io.gravitee.kubernetes.client.model.v1.EndpointSliceList> obs = kubernetesClient
+            .get(ResourceQuery.endpointSlices("test").build())
+            .test();
+
+        obs.await();
+        obs.assertValue(list -> {
+            tc.assertEquals(1, list.getItems().size());
+            return true;
+        });
+    }
+
+    @Test
+    public void should_watch_endpointslice_list() throws InterruptedException {
+        final EndpointSlice slice = buildEndpointSlices().getItems().get(0);
+
+        server
+            .expect()
+            .get()
+            .withPath("/apis/discovery.k8s.io/v1/namespaces/test/endpointslices?watch=true")
+            .andUpgradeToWebSocket()
+            .open()
+            .waitFor(EVENT_WAIT_PERIOD_MS)
+            .andEmit(new WatchEvent(slice, "ADDED"))
+            .waitFor(EVENT_WAIT_PERIOD_MS)
+            .andEmit(new WatchEvent(incrementResourceVersion(slice), "MODIFIED"))
+            .done()
+            .once();
+
+        final TestSubscriber<
+            io.gravitee.kubernetes.client.model.v1.Event<io.gravitee.kubernetes.client.model.v1.EndpointSlice>
+        > obs =
+            kubernetesClient.watch(WatchQuery.<io.gravitee.kubernetes.client.model.v1.EndpointSlice>from("/test/endpointslices").build()).test();
+
+        obs.await();
+        obs.assertValueCount(2);
+        obs.assertValueAt(0, event -> event.getType().equalsIgnoreCase("ADDED"));
+        obs.assertValueAt(1, event -> event.getType().equalsIgnoreCase("MODIFIED"));
+        obs.assertNotComplete();
+    }
+
+    @Test
+    public void should_watch_endpointslice_with_label_and_field_selectors() throws InterruptedException {
+        final EndpointSlice slice = buildEndpointSlices().getItems().get(0);
+
+        server
+            .expect()
+            .get()
+            .withPath(
+                "/apis/discovery.k8s.io/v1/namespaces/test/endpointslices?fieldSelector=field1%3DvalueField1,field2%3DvalueField2&labelSelector=label1%3DvalueLabel1,label2%3DvalueLabel2&watch=true"
+            )
+            .andUpgradeToWebSocket()
+            .open()
+            .waitFor(EVENT_WAIT_PERIOD_MS)
+            .andEmit(new WatchEvent(slice, "MODIFIED"))
+            .done()
+            .once();
+
+        final Flowable<
+            io.gravitee.kubernetes.client.model.v1.Event<io.gravitee.kubernetes.client.model.v1.EndpointSlice>
+        > watch =
+            kubernetesClient.watch(
+                WatchQuery
+                    .<io.gravitee.kubernetes.client.model.v1.EndpointSlice>from("/test/endpointslices")
+                    .fieldSelector(FieldSelector.equals("field1", "valueField1"))
+                    .fieldSelector(FieldSelector.equals("field2", "valueField2"))
+                    .labelSelector(LabelSelector.equals("label1", "valueLabel1"))
+                    .labelSelector(LabelSelector.equals("label2", "valueLabel2"))
+                    .build()
+            );
+
+        final TestSubscriber<
+            io.gravitee.kubernetes.client.model.v1.Event<io.gravitee.kubernetes.client.model.v1.EndpointSlice>
+        > obs = watch.test();
+
+        obs.await();
+        obs.assertValueCount(1);
+        obs.assertNotComplete();
+    }
+
+    private EndpointSlice incrementResourceVersion(EndpointSlice slice) {
+        int i = Integer.parseInt(slice.getMetadata().getResourceVersion());
+        slice.getMetadata().setResourceVersion(String.valueOf(i + 1));
+        return slice;
+    }
+
+    private static EndpointSliceList buildEndpointSlices() {
+        EndpointSlice slice = new EndpointSliceBuilder()
+            .withMetadata(new ObjectMetaBuilder().withName("testEndpointSlice").withResourceVersion("1234").build())
+            .withAddressType("IPv4")
+            .withPorts(new EndpointSlicePortBuilder().withPort(8080).build())
+            .addNewEndpoint()
+            .withAddresses("10.0.0.1")
+            .endEndpoint()
+            .build();
+
+        return new EndpointSliceListBuilder().addToItems(slice).withNewMetadata("1", 0L, "1234", "/selflink").build();
+    }
+}

--- a/gravitee-kubernetes-client/src/test/java/io/gravitee/kubernetes/client/KubernetesEndpointSliceV1Test.java
+++ b/gravitee-kubernetes-client/src/test/java/io/gravitee/kubernetes/client/KubernetesEndpointSliceV1Test.java
@@ -18,10 +18,10 @@ package io.gravitee.kubernetes.client;
 import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
 import io.fabric8.kubernetes.api.model.WatchEvent;
 import io.fabric8.kubernetes.api.model.discovery.EndpointSlice;
+import io.fabric8.kubernetes.api.model.discovery.EndpointSliceBuilder;
 import io.fabric8.kubernetes.api.model.discovery.EndpointSliceList;
 import io.fabric8.kubernetes.api.model.discovery.EndpointSliceListBuilder;
 import io.fabric8.kubernetes.api.model.discovery.EndpointSlicePortBuilder;
-import io.fabric8.kubernetes.api.model.discovery.EndpointSliceBuilder;
 import io.gravitee.kubernetes.client.api.FieldSelector;
 import io.gravitee.kubernetes.client.api.LabelSelector;
 import io.gravitee.kubernetes.client.api.ResourceQuery;
@@ -74,10 +74,10 @@ public class KubernetesEndpointSliceV1Test extends KubernetesUnitTest {
             .done()
             .once();
 
-        final TestSubscriber<
-            io.gravitee.kubernetes.client.model.v1.Event<io.gravitee.kubernetes.client.model.v1.EndpointSlice>
-        > obs =
-            kubernetesClient.watch(WatchQuery.<io.gravitee.kubernetes.client.model.v1.EndpointSlice>from("/test/endpointslices").build()).test();
+        final TestSubscriber<io.gravitee.kubernetes.client.model.v1.Event<io.gravitee.kubernetes.client.model.v1.EndpointSlice>> obs =
+            kubernetesClient
+                .watch(WatchQuery.<io.gravitee.kubernetes.client.model.v1.EndpointSlice>from("/test/endpointslices").build())
+                .test();
 
         obs.await();
         obs.assertValueCount(2);
@@ -103,9 +103,7 @@ public class KubernetesEndpointSliceV1Test extends KubernetesUnitTest {
             .done()
             .once();
 
-        final Flowable<
-            io.gravitee.kubernetes.client.model.v1.Event<io.gravitee.kubernetes.client.model.v1.EndpointSlice>
-        > watch =
+        final Flowable<io.gravitee.kubernetes.client.model.v1.Event<io.gravitee.kubernetes.client.model.v1.EndpointSlice>> watch =
             kubernetesClient.watch(
                 WatchQuery
                     .<io.gravitee.kubernetes.client.model.v1.EndpointSlice>from("/test/endpointslices")
@@ -116,9 +114,8 @@ public class KubernetesEndpointSliceV1Test extends KubernetesUnitTest {
                     .build()
             );
 
-        final TestSubscriber<
-            io.gravitee.kubernetes.client.model.v1.Event<io.gravitee.kubernetes.client.model.v1.EndpointSlice>
-        > obs = watch.test();
+        final TestSubscriber<io.gravitee.kubernetes.client.model.v1.Event<io.gravitee.kubernetes.client.model.v1.EndpointSlice>> obs =
+            watch.test();
 
         obs.await();
         obs.assertValueCount(1);

--- a/gravitee-kubernetes-client/src/test/java/io/gravitee/kubernetes/client/KubernetesEndpointSliceV1Test.java
+++ b/gravitee-kubernetes-client/src/test/java/io/gravitee/kubernetes/client/KubernetesEndpointSliceV1Test.java
@@ -17,11 +17,11 @@ package io.gravitee.kubernetes.client;
 
 import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
 import io.fabric8.kubernetes.api.model.WatchEvent;
+import io.fabric8.kubernetes.api.model.discovery.EndpointPortBuilder;
 import io.fabric8.kubernetes.api.model.discovery.EndpointSlice;
 import io.fabric8.kubernetes.api.model.discovery.EndpointSliceBuilder;
 import io.fabric8.kubernetes.api.model.discovery.EndpointSliceList;
 import io.fabric8.kubernetes.api.model.discovery.EndpointSliceListBuilder;
-import io.fabric8.kubernetes.api.model.discovery.EndpointPortBuilder;
 import io.gravitee.kubernetes.client.api.FieldSelector;
 import io.gravitee.kubernetes.client.api.LabelSelector;
 import io.gravitee.kubernetes.client.api.ResourceQuery;


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/XXXXX

**Description**

A small description of what you did in that PR.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.8.0-feat-endpointslices-support-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/kubernetes/gravitee-kubernetes/3.8.0-feat-endpointslices-support-SNAPSHOT/gravitee-kubernetes-3.8.0-feat-endpointslices-support-SNAPSHOT.zip)
  <!-- Version placeholder end -->
