### PR TITLE
feat: upgrade to Vertx 5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1
 setup: true
 
 orbs:
-    gravitee: gravitee-io/gravitee@4.15.0
+    gravitee: gravitee-io/gravitee@5.4.2
 
 # our single workflow, that triggers the setup job defined above, filters on tag and branches are needed otherwise
 # some workflow and job will not be triggered for tags (default CircleCI behavior)

--- a/gravitee-kubernetes-client/pom.xml
+++ b/gravitee-kubernetes-client/pom.xml
@@ -63,6 +63,14 @@
             <scope>provided</scope>
         </dependency>
 
+        <!-- Lombok -->
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <scope>provided</scope>
+            <optional>true</optional>
+        </dependency>
+
         <!-- Dependencies for tests -->
         <dependency>
             <groupId>io.vertx</groupId>
@@ -94,7 +102,7 @@
 
         <dependency>
             <groupId>org.bouncycastle</groupId>
-            <artifactId>bcpkix-jdk15on</artifactId>
+            <artifactId>bcpkix-jdk18on</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/gravitee-kubernetes-client/src/main/java/io/gravitee/kubernetes/client/config/KubernetesConfig.java
+++ b/gravitee-kubernetes-client/src/main/java/io/gravitee/kubernetes/client/config/KubernetesConfig.java
@@ -351,8 +351,12 @@ public class KubernetesConfig {
             if (clusterName != null) {
                 List<NamedCluster> clusters = config.getClusters();
                 if (clusters != null) {
-                    cluster =
-                        clusters.stream().filter(c -> c.getName().equals(clusterName)).findAny().map(NamedCluster::getCluster).orElse(null);
+                    cluster = clusters
+                        .stream()
+                        .filter(c -> c.getName().equals(clusterName))
+                        .findAny()
+                        .map(NamedCluster::getCluster)
+                        .orElse(null);
                 }
             }
         }
@@ -366,7 +370,12 @@ public class KubernetesConfig {
             if (user != null) {
                 List<NamedAuthInfo> users = config.getUsers();
                 if (users != null) {
-                    authInfo = users.stream().filter(u -> u.getName().equals(user)).findAny().map(NamedAuthInfo::getUser).orElse(null);
+                    authInfo = users
+                        .stream()
+                        .filter(u -> u.getName().equals(user))
+                        .findAny()
+                        .map(NamedAuthInfo::getUser)
+                        .orElse(null);
                 }
             }
         }
@@ -440,9 +449,10 @@ public class KubernetesConfig {
             throw new IllegalArgumentException(String.format("Override Kubernetes config file '%s' does not exist", overrideFile));
         }
 
-        String fileName = System
-            .getenv()
-            .getOrDefault(KUBERNETES_KUBECONFIG_FILE, new File(getHomeDir(), ".kube" + File.separator + "config").toString());
+        String fileName = System.getenv().getOrDefault(
+            KUBERNETES_KUBECONFIG_FILE,
+            new File(getHomeDir(), ".kube" + File.separator + "config").toString()
+        );
 
         // if system property/env var contains multiple files take the first one based on the environment
         // we are running in (eg. : for Linux, ; for Windows)

--- a/gravitee-kubernetes-client/src/main/java/io/gravitee/kubernetes/client/impl/KubernetesClientV1Impl.java
+++ b/gravitee-kubernetes-client/src/main/java/io/gravitee/kubernetes/client/impl/KubernetesClientV1Impl.java
@@ -32,13 +32,21 @@ import io.reactivex.rxjava3.core.FlowableTransformer;
 import io.reactivex.rxjava3.core.Maybe;
 import io.vertx.core.VertxOptions;
 import io.vertx.core.buffer.Buffer;
-import io.vertx.core.http.*;
+import io.vertx.core.http.HttpClientOptions;
+import io.vertx.core.http.HttpHeaders;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.RequestOptions;
+import io.vertx.core.http.UpgradeRejectedException;
+import io.vertx.core.http.WebSocketClientOptions;
+import io.vertx.core.http.WebSocketConnectOptions;
 import io.vertx.core.json.JsonObject;
+import io.vertx.core.net.ClientOptionsBase;
 import io.vertx.core.net.JksOptions;
 import io.vertx.core.net.PemTrustOptions;
 import io.vertx.rxjava3.core.Vertx;
 import io.vertx.rxjava3.core.http.HttpClient;
 import io.vertx.rxjava3.core.http.HttpClientRequest;
+import io.vertx.rxjava3.core.http.WebSocketClient;
 import java.io.ByteArrayOutputStream;
 import java.security.KeyStore;
 import java.util.Map;
@@ -69,6 +77,7 @@ public class KubernetesClientV1Impl implements KubernetesClient {
 
     private final KubernetesConfig config;
     private HttpClient httpClient;
+    private WebSocketClient webSocketClient;
     private final Map<String, Watch> watchMap = new ConcurrentHashMap<>();
     private final Map<String, Pattern> patternCache = new ConcurrentHashMap<>();
 
@@ -100,7 +109,7 @@ public class KubernetesClientV1Impl implements KubernetesClient {
             byte[] body = objectMapper.writeValueAsBytes(item);
             return httpClient()
                 .rxRequest(requestOptions)
-                .flatMap(httpClientRequest -> httpClientRequest.rxSend(io.vertx.rxjava3.core.buffer.Buffer.buffer(body)))
+                .flatMap(httpClientRequest -> httpClientRequest.rxSend(io.vertx.core.buffer.Buffer.buffer(body)))
                 .toMaybe()
                 .flatMap(response -> {
                     if (
@@ -179,14 +188,11 @@ public class KubernetesClientV1Impl implements KubernetesClient {
         String uri = query.toUri();
         String watchKey = "watch" + WATCH_KEY_SEPARATOR + uri.hashCode();
 
-        final Watch<E> watch = watchMap.computeIfAbsent(
-            watchKey,
-            s -> {
-                final Watch<E> w = watchEvents(watchKey, uri, query);
-                w.setEvents(w.events.doFinally(() -> watchMap.remove(watchKey)));
-                return w;
-            }
-        );
+        final Watch<E> watch = watchMap.computeIfAbsent(watchKey, s -> {
+            final Watch<E> w = watchEvents(watchKey, uri, query);
+            w.setEvents(w.events.doFinally(() -> watchMap.remove(watchKey)));
+            return w;
+        });
 
         final String wildcardResource = query.getResource() != null && query.getResource().contains("*") ? query.getResource() : null;
 
@@ -207,8 +213,8 @@ public class KubernetesClientV1Impl implements KubernetesClient {
         final Watch<E> watch = new Watch<>(watchKey);
         final WebSocketConnectOptions webSocketConnectOptions = buildWebSocketConnectOptions(uri);
 
-        final Flowable<E> events = httpClient()
-            .rxWebSocket(webSocketConnectOptions)
+        final Flowable<E> events = webSocketClient()
+            .rxConnect(webSocketConnectOptions)
             .flatMapPublisher(websocket -> {
                 Flowable<E> pingFlowable = websocketPing(websocket);
                 return pingFlowable.compose(
@@ -272,16 +278,19 @@ public class KubernetesClientV1Impl implements KubernetesClient {
     }
 
     private <E> Flowable<E> websocketPing(io.vertx.rxjava3.core.http.WebSocket webSocket) {
-        return Flowable
-            .interval(PING_HANDLER_DELAY, TimeUnit.MILLISECONDS)
+        return Flowable.interval(PING_HANDLER_DELAY, TimeUnit.MILLISECONDS)
             .timestamp()
-            .flatMapCompletable(timed -> webSocket.rxWritePing(io.vertx.rxjava3.core.buffer.Buffer.buffer("ping")))
+            .flatMapCompletable(timed -> webSocket.rxWritePing(io.vertx.core.buffer.Buffer.buffer("ping")))
             .doOnError(throwable -> log.error("An error occurred while sending ping to websocket", throwable))
             .toFlowable();
     }
 
     private <E> FlowableTransformer<E, E> mergeWithFirst(Flowable<E> other) {
-        return upstream -> other.materialize().mergeWith(upstream.materialize()).dematerialize(n -> n);
+        return upstream ->
+            other
+                .materialize()
+                .mergeWith(upstream.materialize())
+                .dematerialize(n -> n);
     }
 
     private RequestOptions getHTTPRequestOptions(HttpMethod post, String uri) {
@@ -313,16 +322,30 @@ public class KubernetesClientV1Impl implements KubernetesClient {
     }
 
     private HttpClientOptions httpClientOptions() {
-        PemTrustOptions trustOptions = new PemTrustOptions();
+        HttpClientOptions options = configureClientOptions(new HttpClientOptions());
+        return options
+            .setVerifyHost(kubeConfig().verifyHost())
+            .setDefaultHost(kubeConfig().getApiServerHost())
+            .setDefaultPort(kubeConfig().getApiServerPort());
+    }
+
+    private WebSocketClientOptions webSocketClientOptions() {
+        WebSocketClientOptions options = configureClientOptions(new WebSocketClientOptions());
+        return options
+            .setVerifyHost(kubeConfig().verifyHost())
+            .setDefaultHost(kubeConfig().getApiServerHost())
+            .setDefaultPort(kubeConfig().getApiServerPort());
+    }
+
+    private <T extends ClientOptionsBase> T configureClientOptions(T options) {
         if (kubeConfig().getCaCertData() == null || kubeConfig().getApiServerHost() == null || kubeConfig().getApiServerPort() == 0) {
             log.error("KubeConfig is not configured properly. If you are running locally make sure you already configured your kubeconfig");
         }
 
+        PemTrustOptions trustOptions = new PemTrustOptions();
         if (kubeConfig().getCaCertData() != null) {
             trustOptions.addCertValue(Buffer.buffer(kubeConfig().getCaCertData()));
         }
-
-        HttpClientOptions opt = new HttpClientOptions();
 
         if (kubeConfig().getClientCertData() != null && kubeConfig().getClientKeyData() != null) {
             // setup mTLS (create a keystore and export and set again as buffer for vertx)
@@ -336,7 +359,7 @@ public class KubernetesClientV1Impl implements KubernetesClient {
                     alias
                 );
                 keyStore.store(output, password.toCharArray());
-                opt.setKeyStoreOptions(
+                options.setKeyCertOptions(
                     new JksOptions().setPassword(password).setAlias(alias).setValue(Buffer.buffer(output.toByteArray()))
                 );
             } catch (Exception e) {
@@ -344,14 +367,13 @@ public class KubernetesClientV1Impl implements KubernetesClient {
             }
         }
 
-        return opt
+        options
             .setTrustOptions(trustOptions)
-            .setVerifyHost(kubeConfig().verifyHost())
             .setTrustAll(!kubeConfig().verifyHost())
-            .setDefaultHost(kubeConfig().getApiServerHost())
-            .setDefaultPort(kubeConfig().getApiServerPort())
             .setConnectTimeout(kubeConfig().getApiTimeout())
             .setSsl(kubeConfig().useSSL());
+
+        return options;
     }
 
     public synchronized HttpClient httpClient() {
@@ -360,6 +382,14 @@ public class KubernetesClientV1Impl implements KubernetesClient {
         }
 
         return httpClient;
+    }
+
+    public synchronized io.vertx.rxjava3.core.http.WebSocketClient webSocketClient() {
+        if (webSocketClient == null) {
+            this.webSocketClient = VERTX.createWebSocketClient(webSocketClientOptions());
+        }
+
+        return webSocketClient;
     }
 
     private static class Watch<E extends Event<? extends Watchable>> {

--- a/gravitee-kubernetes-client/src/main/java/io/gravitee/kubernetes/client/model/v1/Error.java
+++ b/gravitee-kubernetes-client/src/main/java/io/gravitee/kubernetes/client/model/v1/Error.java
@@ -40,5 +40,6 @@ public class Error {
         private String message;
         private String reason;
         private int code;
+        private Object subsets;
     }
 }

--- a/gravitee-kubernetes-client/src/test/java/io/gravitee/kubernetes/client/KubernetesEndpointsV1Test.java
+++ b/gravitee-kubernetes-client/src/test/java/io/gravitee/kubernetes/client/KubernetesEndpointsV1Test.java
@@ -151,8 +151,7 @@ public class KubernetesEndpointsV1Test extends KubernetesUnitTest {
 
         final Flowable<io.gravitee.kubernetes.client.model.v1.Event<io.gravitee.kubernetes.client.model.v1.Secret>> watch1 =
             kubernetesClient.watch(
-                WatchQuery
-                    .<io.gravitee.kubernetes.client.model.v1.Secret>from("/test/endpoints")
+                WatchQuery.<io.gravitee.kubernetes.client.model.v1.Secret>from("/test/endpoints")
                     .fieldSelector(FieldSelector.equals("field1", "valueField1"))
                     .fieldSelector(FieldSelector.equals("field2", "valueField2"))
                     .labelSelector(LabelSelector.equals("label1", "valueLabel1"))

--- a/gravitee-kubernetes-client/src/test/java/io/gravitee/kubernetes/client/KubernetesSecretV1Test.java
+++ b/gravitee-kubernetes-client/src/test/java/io/gravitee/kubernetes/client/KubernetesSecretV1Test.java
@@ -383,8 +383,7 @@ public class KubernetesSecretV1Test extends KubernetesUnitTest {
 
         final Flowable<io.gravitee.kubernetes.client.model.v1.Event<io.gravitee.kubernetes.client.model.v1.Secret>> watch1 =
             kubernetesClient.watch(
-                WatchQuery
-                    .<io.gravitee.kubernetes.client.model.v1.Secret>from("/test/secrets")
+                WatchQuery.<io.gravitee.kubernetes.client.model.v1.Secret>from("/test/secrets")
                     .fieldSelector(FieldSelector.equals("field1", "valueField1"))
                     .fieldSelector(FieldSelector.equals("field2", "valueField2"))
                     .labelSelector(LabelSelector.equals("label1", "valueLabel1"))
@@ -465,9 +464,8 @@ public class KubernetesSecretV1Test extends KubernetesUnitTest {
             kubernetesClient.watch(WatchQuery.<io.gravitee.kubernetes.client.model.v1.Secret>from("/test/secrets/secret1").build());
         final Flowable<io.gravitee.kubernetes.client.model.v1.Event<io.gravitee.kubernetes.client.model.v1.Secret>> watch2 =
             kubernetesClient.watch(WatchQuery.<io.gravitee.kubernetes.client.model.v1.Secret>from("/test/secrets/secret2").build());
-        final TestSubscriber<io.gravitee.kubernetes.client.model.v1.Event<io.gravitee.kubernetes.client.model.v1.Secret>> obs = Flowable
-            .mergeArray(watch1, watch2)
-            .test();
+        final TestSubscriber<io.gravitee.kubernetes.client.model.v1.Event<io.gravitee.kubernetes.client.model.v1.Secret>> obs =
+            Flowable.mergeArray(watch1, watch2).test();
 
         obs.await();
         obs.assertValueCount(3);

--- a/gravitee-kubernetes-client/src/test/java/io/gravitee/kubernetes/client/api/ResourceQueryTest.java
+++ b/gravitee-kubernetes-client/src/test/java/io/gravitee/kubernetes/client/api/ResourceQueryTest.java
@@ -53,8 +53,7 @@ class ResourceQueryTest {
 
     @Test
     void should_get_secrets_from_namespace_field_selector() {
-        ResourceQuery<SecretList> query = ResourceQuery
-            .secrets("my-namespace")
+        ResourceQuery<SecretList> query = ResourceQuery.secrets("my-namespace")
             .fieldSelector(FieldSelector.equals("status.hostIP", "172.17.8.101"))
             .build();
 
@@ -63,8 +62,7 @@ class ResourceQueryTest {
 
     @Test
     void should_get_secrets_from_namespace_field_selector_using_from() {
-        ResourceQuery<SecretList> query = ResourceQuery
-            .<SecretList>from("/my-namespace/secrets")
+        ResourceQuery<SecretList> query = ResourceQuery.<SecretList>from("/my-namespace/secrets")
             .fieldSelector(FieldSelector.equals("status.hostIP", "172.17.8.101"))
             .build();
 

--- a/gravitee-kubernetes-client/src/test/java/io/gravitee/kubernetes/client/api/WatchQueryTest.java
+++ b/gravitee-kubernetes-client/src/test/java/io/gravitee/kubernetes/client/api/WatchQueryTest.java
@@ -59,8 +59,7 @@ class WatchQueryTest {
 
     @Test
     void shouldGetSecretsFromNamespace_fieldSelector_usingFrom() {
-        WatchQuery<Event<Secret>> query = WatchQuery
-            .<Secret>from("/my-namespace/secrets")
+        WatchQuery<Event<Secret>> query = WatchQuery.<Secret>from("/my-namespace/secrets")
             .fieldSelector(FieldSelector.equals("status.hostIP", "172.17.8.101"))
             .build();
 

--- a/gravitee-kubernetes-client/src/test/java/io/gravitee/kubernetes/client/impl/HttpClientConfigurationTest.java
+++ b/gravitee-kubernetes-client/src/test/java/io/gravitee/kubernetes/client/impl/HttpClientConfigurationTest.java
@@ -33,6 +33,7 @@ class HttpClientConfigurationTest {
         assertThat(config.getAccessToken()).isNull();
         KubernetesClientV1Impl kubernetesClientV1 = new KubernetesClientV1Impl(config);
         assertThatCode(kubernetesClientV1::httpClient).doesNotThrowAnyException();
+        assertThatCode(kubernetesClientV1::webSocketClient).doesNotThrowAnyException();
     }
 
     @Test
@@ -40,5 +41,6 @@ class HttpClientConfigurationTest {
         KubernetesConfig config = KubernetesConfig.newInstance("src/test/resources/config.yaml");
         KubernetesClientV1Impl kubernetesClientV1 = new KubernetesClientV1Impl(config);
         assertThatCode(kubernetesClientV1::httpClient).doesNotThrowAnyException();
+        assertThatCode(kubernetesClientV1::webSocketClient).doesNotThrowAnyException();
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>22.5.1</version>
+        <version>23.5.0</version>
     </parent>
 
     <groupId>io.gravitee.kubernetes</groupId>
@@ -38,9 +38,9 @@
     </modules>
 
     <properties>
-        <gravitee-bom.version>6.0.62</gravitee-bom.version>
-        <gravitee-common.version>3.4.2</gravitee-common.version>
-        <gravitee-node.version>4.8.9</gravitee-node.version>
+        <gravitee-bom.version>9.0.0-beta.2</gravitee-bom.version>
+        <gravitee-common.version>5.0.0-beta.1</gravitee-common.version>
+        <gravitee-node.version>8.0.0-beta.2</gravitee-node.version>
         <fabric8.version>4.13.3</fabric8.version>
         <sonar.skip>true</sonar.skip>
         <junit-vintage-engine.version>5.8.2</junit-vintage-engine.version>


### PR DESCRIPTION
BREAKING CHANGE: upgrade to Vert.x 5

**Issue**

https://gravitee.atlassian.net/browse/ARCHI-601

**Description**

Prepare Vert.x 5 upgrade

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `4.0.0-feat-migrate-vertx5-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/kubernetes/gravitee-kubernetes/4.0.0-feat-migrate-vertx5-SNAPSHOT/gravitee-kubernetes-4.0.0-feat-migrate-vertx5-SNAPSHOT.zip)
  <!-- Version placeholder end -->
